### PR TITLE
Fixes deprecated message when passing null to sanitize_stripslashes_deep()

### DIFF
--- a/core/Helpers.php
+++ b/core/Helpers.php
@@ -139,6 +139,7 @@ class Helpers {
 		} elseif ( is_bool( $value ) ) {
 			return $value;
 		} else {
+			$value = $value ?? '';
 			return sanitize_textarea_field( stripslashes( $value ) );
 		}
 	}


### PR DESCRIPTION
When `$value` is null, `stripslashes()` generates a warning as [it expects a string](https://www.php.net/manual/en/function.stripslashes.php). This PR removes that warning by converting null values into empty strings. Relates to [this ticket](https://wordpress.org/support/topic/llar-deprecated-warnings-on-login-screen/).