### PR TITLE
Fixes deprecated partially-supported callable

### DIFF
--- a/core/Helpers.php
+++ b/core/Helpers.php
@@ -135,7 +135,7 @@ class Helpers {
 	public static function sanitize_stripslashes_deep( $value )
 	{
 		if ( is_array( $value ) ) {
-			return array_map( 'self::sanitize_stripslashes_deep', $value );
+			return array_map( [Helpers::class, 'sanitize_stripslashes_deep'], $value );
 		} elseif ( is_bool( $value ) ) {
 			return $value;
 		} else {


### PR DESCRIPTION
`sanitize_stripslashes_deep()` uses `self::sanitize_stripslashes_deep` which is deprecated in php 8.2 and will be an error in 9.0. See [this note on php watch]( https://php.watch/versions/8.2/partially-supported-callable-deprecation). This PR switches to an accepted syntax.

Relates to [this ticket](https://wordpress.org/support/topic/llar-deprecated-warnings-on-login-screen/).