### PR TITLE
Improve local risk indicator thresholds and refactor rendering

### DIFF
--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -433,12 +433,11 @@ class LimitLoginAttempts
 	/**
 	 * Build recommendation description for elevated brute force activity.
 	 *
-	 * @param string $setup_code          App setup code.
-	 * @param string $upgrade_premium_url Premium upgrade URL.
+	 * @param string $setup_code App setup code.
 	 *
 	 * @return string
 	 */
-	private function get_recommendation_desc( $setup_code, $upgrade_premium_url ) {
+	private function get_recommendation_desc( $setup_code ) {
 		if ( ! empty( $setup_code ) ) {
 			$premium_tab_url = $this->get_options_page_uri( 'premium' );
 			return $this->get_premium_recommendation_desc( $premium_tab_url, false );
@@ -517,9 +516,12 @@ class LimitLoginAttempts
 					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
 					break;
 				case 'warning_title':
-					$medium_upper = 300;
-					if ( isset( $risk_config['bounds']['medium_upper'] ) ) {
-						$medium_upper = (int) $risk_config['bounds']['medium_upper'];
+					$medium_upper = isset( $risk_config['bounds']['medium_upper'] ) ? (int) $risk_config['bounds']['medium_upper'] : 0;
+					if ( $medium_upper <= 0 && isset( $matched_level['min_inclusive'] ) ) {
+						$medium_upper = (int) $matched_level['min_inclusive'];
+					}
+					if ( $medium_upper <= 0 ) {
+						$medium_upper = 300;
 					}
 					/* translators: %d: threshold count (e.g. 300) for "N+ failed login attempts" (high risk, local mode). */
 					$retries_chart_title = sprintf(
@@ -533,7 +535,7 @@ class LimitLoginAttempts
 					}
 					break;
 				case 'recommendation':
-					$recommendation_html = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
+					$recommendation_html = $this->get_recommendation_desc( $setup_code );
 					if ( ! empty( $retries_chart_desc ) ) {
 						$retries_chart_desc .= '<br><br>' . $recommendation_html;
 					} else {
@@ -574,7 +576,7 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
-		$risk_config         = function_exists( 'llar_get_risk_config' ) ? llar_get_risk_config() : array();
+		$risk_config         = llar_get_risk_config();
 		$risk_levels         = ( isset( $risk_config['levels'] ) && is_array( $risk_config['levels'] ) ) ? $risk_config['levels'] : array();
 		$risk_colors         = ( isset( $risk_config['colors'] ) && is_array( $risk_config['colors'] ) ) ? $risk_config['colors'] : array();
 		$retries_chart_title = '';

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -386,13 +386,13 @@ class LimitLoginAttempts
 					$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
 					$retries_chart_color = '#FFCC66';
 					break;
-				case 500 > $retries_count:
+				case 300 > $retries_count:
 					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
 					$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
-					$retries_chart_color = '#FF4D4F';
+					$retries_chart_color = '#FFCC66';
 					break;
 				default:
-					$retries_chart_title = __( 'Warning: Your site has experienced over 500 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
+					$retries_chart_title = __( 'Warning: Your site has experienced over 300 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
 					$retries_chart_desc = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
 					$retries_chart_color = '#FF6633';
 					break;

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -456,6 +456,8 @@ class LimitLoginAttempts
 	 * @param bool|array  $api_stats            Cloud API stats.
 	 *
 	 * @return array
+	 *
+	 * QA: use LLA_RISK_CIRCLE_CONFIG_JSON in wp-config.php (see llar_define_risk_config) or legacy LLA_DEBUG_CHART_RETRIES.
 	 */
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
 		$risk_config         = LLA_RISK_CONFIG;
@@ -468,7 +470,13 @@ class LimitLoginAttempts
 		$retries_count       = 0;
 
 		if ( ! $is_active_app_custom ) {
-			$retries_count = $this->get_local_retries_count_for_last_day();
+			$retries_raw   = $this->get_local_retries_count_for_last_day();
+			$retries_count = $retries_raw;
+			$qa_force        = llar_risk_qa_force_retries();
+			if ( null !== $qa_force ) {
+				$retries_count = $qa_force;
+			}
+
 			$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['local'] );
 			$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
 			$retries_chart_title = $display_data['retries_chart_title'];
@@ -489,6 +497,24 @@ class LimitLoginAttempts
 				$retries_chart_title = __( $risk_texts['failed_today_title'], 'limit-login-attempts-reloaded' );
 				$retries_chart_color = $risk_colors['green'];
 			}
+		}
+
+		// QA: optional local risk display (count + color/title/desc) when Cloud App would otherwise show green cloud copy.
+		if ( llar_risk_qa_force_local_risk_ui() ) {
+			$qa_force = llar_risk_qa_force_retries();
+			if ( null !== $qa_force ) {
+				$retries_count = $qa_force;
+				$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['local'] );
+				$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
+				$retries_chart_title = $display_data['retries_chart_title'];
+				$retries_chart_desc = $display_data['retries_chart_desc'];
+				$retries_chart_color = $display_data['retries_chart_color'];
+			}
+		}
+
+		$qa_force_final = llar_risk_qa_force_retries();
+		if ( null !== $qa_force_final ) {
+			$retries_count = $qa_force_final;
 		}
 
 		return array(

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -311,10 +311,12 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_retries_chart_title_with_count( $retries_count ) {
+		$risk_texts = LLA_RISK_CONFIG['texts'];
+
 		return sprintf(
-			_n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ),
+			_n( $risk_texts['count_attempt_single'], $risk_texts['count_attempt_plural'], $retries_count, 'limit-login-attempts-reloaded' ),
 			$retries_count
-		) . __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
+		) . __( $risk_texts['count_attempt_suffix'], 'limit-login-attempts-reloaded' );
 	}
 
 	/**
@@ -326,12 +328,14 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_recommendation_desc( $setup_code, $upgrade_premium_url ) {
+		$risk_texts = LLA_RISK_CONFIG['texts'];
+
 		if ( ! empty( $setup_code ) ) {
 			return $this->get_premium_recommendation_desc( $upgrade_premium_url );
 		}
 
 		return sprintf(
-			__( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
+			__( $risk_texts['recommend_micro_cloud'], 'limit-login-attempts-reloaded' ),
 			'button_micro_cloud'
 		);
 	}
@@ -344,9 +348,98 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
+		$risk_texts = LLA_RISK_CONFIG['texts'];
+
 		return sprintf(
-			__( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
+			__( $risk_texts['recommend_premium'], 'limit-login-attempts-reloaded' ),
 			$upgrade_premium_url
+		);
+	}
+
+	/**
+	 * Resolve risk level by retries count using configured ranges.
+	 *
+	 * @param int   $retries_count Retries count.
+	 * @param array $levels        Risk levels config.
+	 *
+	 * @return array
+	 */
+	private function resolve_risk_level( $retries_count, $levels ) {
+		foreach ( $levels as $level ) {
+			if ( isset( $level['exact'] ) && (int) $level['exact'] === $retries_count ) {
+				return $level;
+			}
+
+			if ( isset( $level['max_exclusive'] ) && (int) $level['max_exclusive'] > $retries_count ) {
+				return $level;
+			}
+
+			if ( ! empty( $level['default'] ) ) {
+				return $level;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Build chart title/description/color from matched risk level.
+	 *
+	 * @param array  $matched_level        Matched level config.
+	 * @param int    $retries_count        Retries count.
+	 * @param array  $risk_config          Risk config.
+	 * @param string $setup_code           App setup code.
+	 * @param string $upgrade_premium_url  Premium upgrade URL.
+	 *
+	 * @return array
+	 */
+	private function build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url ) {
+		$risk_texts = $risk_config['texts'];
+		$risk_colors = $risk_config['colors'];
+
+		$retries_chart_title = '';
+		$retries_chart_desc = '';
+		$retries_chart_color = $risk_colors['green'];
+
+		foreach ( array( 'title', 'count_title', 'warning_title', 'desc', 'recommendation', 'premium_recommendation', 'color' ) as $rule_key ) {
+			if ( empty( $matched_level[ $rule_key ] ) ) {
+				continue;
+			}
+
+			switch ( $rule_key ) {
+				case 'title':
+					$retries_chart_title = __( $risk_texts[ $matched_level['title'] ], 'limit-login-attempts-reloaded' );
+					break;
+				case 'count_title':
+					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
+					break;
+				case 'warning_title':
+					$retries_chart_title = sprintf(
+						__( $risk_texts['warning_title_template'], 'limit-login-attempts-reloaded' ),
+						(int) $risk_config['bounds']['medium_upper']
+					);
+					break;
+				case 'desc':
+					$retries_chart_desc = __( $risk_texts[ $matched_level['desc'] ], 'limit-login-attempts-reloaded' );
+					break;
+				case 'recommendation':
+					$retries_chart_desc = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
+					break;
+				case 'premium_recommendation':
+					$retries_chart_desc = $this->get_premium_recommendation_desc( $upgrade_premium_url );
+					break;
+				case 'color':
+					if ( isset( $risk_colors[ $matched_level['color'] ] ) ) {
+						$retries_chart_color = $risk_colors[ $matched_level['color'] ];
+					}
+					break;
+			}
+		}
+
+		return array(
+			'retries_chart_title' => $retries_chart_title,
+			'retries_chart_desc'  => $retries_chart_desc,
+			'retries_chart_color' => $retries_chart_color,
 		);
 	}
 
@@ -363,6 +456,10 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
+		$risk_config         = LLA_RISK_CONFIG;
+		$risk_texts          = $risk_config['texts'];
+		$risk_levels         = $risk_config['levels'];
+		$risk_colors         = $risk_config['colors'];
 		$retries_chart_title = '';
 		$retries_chart_desc  = '';
 		$retries_chart_color = '';
@@ -370,57 +467,25 @@ class LimitLoginAttempts
 
 		if ( ! $is_active_app_custom ) {
 			$retries_count = $this->get_local_retries_count_for_last_day();
-
-			switch ( true ) {
-				case 0 === $retries_count:
-					$retries_chart_title = __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
-					$retries_chart_color = '#97F6C8';
-					break;
-				case 100 > $retries_count:
-					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
-					$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
-					$retries_chart_color = '#FFE066';
-					break;
-				case 300 > $retries_count:
-					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
-					$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
-					$retries_chart_color = '#FFCC66';
-					break;
-				case 300 > $retries_count:
-					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
-					$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
-					$retries_chart_color = '#FFCC66';
-					break;
-				default:
-					$retries_chart_title = __( 'Warning: Your site has experienced over 300 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
-					$retries_chart_desc = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
-					$retries_chart_color = '#FF6633';
-					break;
-			}
+			$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['local'] );
+			$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
+			$retries_chart_title = $display_data['retries_chart_title'];
+			$retries_chart_desc = $display_data['retries_chart_desc'];
+			$retries_chart_color = $display_data['retries_chart_color'];
 		} else {
 			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) ) {
 				$retries_count = (int) end( $api_stats['attempts']['count'] );
 			}
 
 			if ( $is_exhausted && 'Micro Cloud' === $block_sub_group ) {
-				switch ( true ) {
-					case 0 === $retries_count:
-						$retries_chart_title = __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
-						$retries_chart_color = '#97F6C8';
-						break;
-					case 100 > $retries_count:
-						$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
-						$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
-						$retries_chart_color = '#FFCC66';
-						break;
-					default:
-						$retries_chart_desc = $this->get_premium_recommendation_desc( $upgrade_premium_url );
-						$retries_chart_color = '#FF6633';
-						break;
-				}
+				$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['cloud_exhausted_micro'] );
+				$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
+				$retries_chart_title = $display_data['retries_chart_title'];
+				$retries_chart_desc = $display_data['retries_chart_desc'];
+				$retries_chart_color = $display_data['retries_chart_color'];
 			} else {
-				$retries_chart_title = __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
-				$retries_chart_color = '#97F6C8';
+				$retries_chart_title = __( $risk_texts['failed_today_title'], 'limit-login-attempts-reloaded' );
+				$retries_chart_color = $risk_colors['green'];
 			}
 		}
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -282,14 +282,22 @@ class LimitLoginAttempts
 	}
 
 	/**
-	 * Ensure risk config is loaded (llar_get_risk_config builds once per request).
+	 * Whether a retries_stats bucket key is older than cutoff (safe strtotime for string keys).
 	 *
-	 * @return void
+	 * @param mixed $key    Bucket key (unix ts or date string).
+	 * @param int   $cutoff Cutoff unix timestamp.
+	 *
+	 * @return bool
 	 */
-	private function ensure_llar_risk_config_defined() {
-		if ( function_exists( 'llar_get_risk_config' ) ) {
-			llar_get_risk_config();
+	private function is_retries_stats_bucket_expired( $key, $cutoff ) {
+		if ( is_numeric( $key ) ) {
+			return (int) $key < $cutoff;
 		}
+		$ts = strtotime( (string) $key );
+		if ( false === $ts ) {
+			return false;
+		}
+		return $ts < $cutoff;
 	}
 
 	/**
@@ -307,8 +315,6 @@ class LimitLoginAttempts
 				return __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
 			case 'desc_medium':
 				return __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
-			case 'warning_title_template':
-				return __( 'Warning: Your site has experienced 300+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
 			case 'failed_today_title':
 				return __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
 			default:
@@ -403,10 +409,7 @@ class LimitLoginAttempts
 
 		$cutoff = strtotime( '-8 day' );
 		foreach ( $retries_stats as $key => $count ) {
-			if (
-				( is_numeric( $key ) && (int) $key < $cutoff )
-				|| ( ! is_numeric( $key ) && strtotime( $key ) < $cutoff )
-			) {
+			if ( $this->is_retries_stats_bucket_expired( $key, $cutoff ) ) {
 				unset( $retries_stats[ $key ] );
 			}
 		}
@@ -489,11 +492,12 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	private function build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url ) {
-		$risk_colors = $risk_config['colors'];
+		$risk_colors = ( isset( $risk_config['colors'] ) && is_array( $risk_config['colors'] ) ) ? $risk_config['colors'] : array();
+		$default_color = isset( $risk_colors['green'] ) ? $risk_colors['green'] : '#97F6C8';
 
 		$retries_chart_title = '';
 		$retries_chart_desc = '';
-		$retries_chart_color = $risk_colors['green'];
+		$retries_chart_color = $default_color;
 
 		foreach ( array( 'title', 'count_title', 'warning_title', 'desc', 'recommendation', 'premium_recommendation', 'color' ) as $rule_key ) {
 			if ( empty( $matched_level[ $rule_key ] ) ) {
@@ -510,7 +514,15 @@ class LimitLoginAttempts
 					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
 					break;
 				case 'warning_title':
-					$retries_chart_title = $this->get_risk_circle_string( 'warning_title_template' );
+					$medium_upper = 300;
+					if ( isset( $risk_config['bounds']['medium_upper'] ) ) {
+						$medium_upper = (int) $risk_config['bounds']['medium_upper'];
+					}
+					/* translators: %d: threshold count (e.g. 300) for "N+ failed login attempts". */
+					$retries_chart_title = sprintf(
+						__( 'Warning: Your site has experienced %d+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' ),
+						$medium_upper
+					);
 					break;
 				case 'desc':
 					if ( ! empty( $matched_level['desc'] ) ) {
@@ -556,11 +568,9 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
-		$this->ensure_llar_risk_config_defined();
-
-		$risk_config         = llar_get_risk_config();
-		$risk_levels         = $risk_config['levels'];
-		$risk_colors         = $risk_config['colors'];
+		$risk_config         = function_exists( 'llar_get_risk_config' ) ? llar_get_risk_config() : array();
+		$risk_levels         = ( isset( $risk_config['levels'] ) && is_array( $risk_config['levels'] ) ) ? $risk_config['levels'] : array();
+		$risk_colors         = ( isset( $risk_config['colors'] ) && is_array( $risk_config['colors'] ) ) ? $risk_config['colors'] : array();
 		$retries_chart_title = '';
 		$retries_chart_desc  = '';
 		$retries_chart_color = '';
@@ -569,29 +579,35 @@ class LimitLoginAttempts
 		if ( ! $is_active_app_custom ) {
 			$retries_count = $this->get_local_retries_count_for_last_day();
 
-			$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['local'] );
+			$local_levels  = isset( $risk_levels['local'] ) && is_array( $risk_levels['local'] ) ? $risk_levels['local'] : array();
+			$matched_level = $this->resolve_risk_level( $retries_count, $local_levels );
 			$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
 			$retries_chart_title = $display_data['retries_chart_title'];
 			$retries_chart_desc = $display_data['retries_chart_desc'];
 			$retries_chart_color = $display_data['retries_chart_color'];
 		} else {
 			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) && is_array( $api_stats['attempts']['count'] ) ) {
-				$attempt_counts = array_values( $api_stats['attempts']['count'] );
-				$n = count( $attempt_counts );
-				if ( $n > 0 ) {
-					$retries_count = (int) $attempt_counts[ $n - 1 ];
+				$attempt_counts = array();
+				foreach ( $api_stats['attempts']['count'] as $v ) {
+					if ( is_numeric( $v ) ) {
+						$attempt_counts[] = (int) $v;
+					}
+				}
+				if ( ! empty( $attempt_counts ) ) {
+					$retries_count = (int) end( $attempt_counts );
 				}
 			}
 
 			if ( $is_exhausted && 'Micro Cloud' === $block_sub_group ) {
-				$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['cloud_exhausted_micro'] );
+				$cloud_levels  = isset( $risk_levels['cloud_exhausted_micro'] ) && is_array( $risk_levels['cloud_exhausted_micro'] ) ? $risk_levels['cloud_exhausted_micro'] : array();
+				$matched_level = $this->resolve_risk_level( $retries_count, $cloud_levels );
 				$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
 				$retries_chart_title = $display_data['retries_chart_title'];
 				$retries_chart_desc = $display_data['retries_chart_desc'];
 				$retries_chart_color = $display_data['retries_chart_color'];
 			} else {
 				$retries_chart_title = $this->get_risk_circle_string( 'failed_today_title' );
-				$retries_chart_color = $risk_colors['green'];
+				$retries_chart_color = isset( $risk_colors['green'] ) ? $risk_colors['green'] : '#97F6C8';
 			}
 		}
 
@@ -2619,15 +2635,13 @@ class LimitLoginAttempts
 
 		$retries_stats = Config::get( 'retries_stats' );
 
-		if($retries_stats) {
+		if ( $retries_stats ) {
 
-			foreach( $retries_stats as $key => $count ) {
+			$stats_cutoff = strtotime( '-8 day' );
+			foreach ( $retries_stats as $key => $count ) {
 
-				if (
-					( is_numeric( $key ) && $key < strtotime( '-8 day' ) )
-					|| ( ! is_numeric( $key ) && strtotime( $key ) < strtotime( '-8 day' ) )
-				) {
-					unset($retries_stats[$key]);
+				if ( $this->is_retries_stats_bucket_expired( $key, $stats_cutoff ) ) {
+					unset( $retries_stats[ $key ] );
 				}
 			}
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -360,12 +360,6 @@ class LimitLoginAttempts
 	 * @return int
 	 */
 	public function get_local_retries_count_for_last_day() {
-		$cache_key = 'llar_local_retries_24h_v1';
-		$cached    = wp_cache_get( $cache_key, 'limit-login-attempts-reloaded' );
-		if ( false !== $cached ) {
-			return (int) $cached;
-		}
-
 		$retries_count = 0;
 		$retries_stats = Config::get( 'retries_stats' );
 
@@ -380,19 +374,7 @@ class LimitLoginAttempts
 			}
 		}
 
-		$retries_count = (int) $retries_count;
-		wp_cache_set( $cache_key, $retries_count, 'limit-login-attempts-reloaded', 60 );
-
-		return $retries_count;
-	}
-
-	/**
-	 * Invalidate cached 24h retries total (call when retries_stats changes).
-	 *
-	 * @return void
-	 */
-	private function bust_local_retries_count_cache() {
-		wp_cache_delete( 'llar_local_retries_24h_v1', 'limit-login-attempts-reloaded' );
+		return (int) $retries_count;
 	}
 
 	/**
@@ -1919,7 +1901,6 @@ class LimitLoginAttempts
 			}
 			$retries_stats = $this->prune_retries_stats_old_buckets( $retries_stats );
 			Config::update( 'retries_stats', $retries_stats );
-			$this->bust_local_retries_count_cache();
 
 			/* Check validity and add one to retries */
 			if ( isset( $retries[ $ip ] ) && isset( $valid[ $ip ] ) && time() < $valid[ $ip ] ) {
@@ -2650,7 +2631,6 @@ class LimitLoginAttempts
 			}
 
 			Config::update( 'retries_stats', $retries_stats );
-			$this->bust_local_retries_count_cache();
 		}
 
 		Config::update( 'retries', $retries );

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -282,16 +282,61 @@ class LimitLoginAttempts
 	}
 
 	/**
+	 * Ensure LLA_RISK_CONFIG exists if something runs before init.
+	 *
+	 * @return void
+	 */
+	private function ensure_llar_risk_config_defined() {
+		if ( ! defined( 'LLA_RISK_CONFIG' ) && function_exists( 'llar_define_risk_config' ) ) {
+			llar_define_risk_config();
+		}
+	}
+
+	/**
+	 * Translated string for failed-attempts circle (whitelist keys; static msgids only).
+	 *
+	 * @param string $key Level text key, e.g. zero_title, desc_low, recommend_premium.
+	 *
+	 * @return string
+	 */
+	private function get_risk_circle_string( $key ) {
+		switch ( $key ) {
+			case 'zero_title':
+				return __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
+			case 'desc_low':
+				return __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
+			case 'desc_medium':
+				return __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
+			case 'warning_title_template':
+				return __( 'Warning: Your site has experienced 300+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
+			case 'recommend_premium':
+				return __( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
+			case 'recommend_micro_cloud':
+				return __( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
+			case 'failed_today_title':
+				return __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
+			default:
+				return '';
+		}
+	}
+
+	/**
 	 * Get failed login attempts count for the last 24 hours in local mode.
 	 *
 	 * @return int
 	 */
 	public function get_local_retries_count_for_last_day() {
+		$cache_key = 'llar_local_retries_24h_v1';
+		$cached    = wp_cache_get( $cache_key, 'limit-login-attempts-reloaded' );
+		if ( false !== $cached ) {
+			return (int) $cached;
+		}
+
 		$retries_count = 0;
 		$retries_stats = Config::get( 'retries_stats' );
 
 		if ( $retries_stats ) {
-			$cutoff_ts = current_time( 'timestamp' ) - DAY_IN_SECONDS;
+			$cutoff_ts = time() - DAY_IN_SECONDS;
 			foreach ( $retries_stats as $key => $count ) {
 				if ( is_numeric( $key ) && (int) $key > $cutoff_ts ) {
 					$retries_count += $count;
@@ -301,7 +346,19 @@ class LimitLoginAttempts
 			}
 		}
 
-		return (int) $retries_count;
+		$retries_count = (int) $retries_count;
+		wp_cache_set( $cache_key, $retries_count, 'limit-login-attempts-reloaded', 60 );
+
+		return $retries_count;
+	}
+
+	/**
+	 * Invalidate cached 24h retries total (call when retries_stats changes).
+	 *
+	 * @return void
+	 */
+	private function bust_local_retries_count_cache() {
+		wp_cache_delete( 'llar_local_retries_24h_v1', 'limit-login-attempts-reloaded' );
 	}
 
 	/**
@@ -312,15 +369,15 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_retries_chart_title_with_count( $retries_count ) {
-		$risk_texts = LLA_RISK_CONFIG['texts'];
-		$single     = isset( $risk_texts['count_attempt_single'] ) ? $risk_texts['count_attempt_single'] : '';
-		$plural     = isset( $risk_texts['count_attempt_plural'] ) ? $risk_texts['count_attempt_plural'] : '';
-		$suffix     = isset( $risk_texts['count_attempt_suffix'] ) ? $risk_texts['count_attempt_suffix'] : '';
-
 		return sprintf(
-			_n( $single, $plural, $retries_count, 'limit-login-attempts-reloaded' ),
+			_n(
+				__( '%d failed login attempt ', 'limit-login-attempts-reloaded' ),
+				__( '%d failed login attempts ', 'limit-login-attempts-reloaded' ),
+				$retries_count,
+				'limit-login-attempts-reloaded'
+			),
 			$retries_count
-		) . __( $suffix, 'limit-login-attempts-reloaded' );
+		) . __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
 	}
 
 	/**
@@ -332,17 +389,13 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_recommendation_desc( $setup_code, $upgrade_premium_url ) {
-		$risk_texts = LLA_RISK_CONFIG['texts'];
-
 		if ( ! empty( $setup_code ) ) {
 			return $this->get_premium_recommendation_desc( $upgrade_premium_url );
 		}
 
-		$template = isset( $risk_texts['recommend_micro_cloud'] ) ? $risk_texts['recommend_micro_cloud'] : '';
-
 		return sprintf(
-			__( $template, 'limit-login-attempts-reloaded' ),
-			'button_micro_cloud'
+			$this->get_risk_circle_string( 'recommend_micro_cloud' ),
+			esc_attr( 'button_micro_cloud' )
 		);
 	}
 
@@ -354,11 +407,8 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
-		$risk_texts = LLA_RISK_CONFIG['texts'];
-		$template   = isset( $risk_texts['recommend_premium'] ) ? $risk_texts['recommend_premium'] : '';
-
 		return sprintf(
-			__( $template, 'limit-login-attempts-reloaded' ),
+			$this->get_risk_circle_string( 'recommend_premium' ),
 			esc_url( $upgrade_premium_url )
 		);
 	}
@@ -403,7 +453,6 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	private function build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url ) {
-		$risk_texts = $risk_config['texts'];
 		$risk_colors = $risk_config['colors'];
 
 		$retries_chart_title = '';
@@ -417,21 +466,19 @@ class LimitLoginAttempts
 
 			switch ( $rule_key ) {
 				case 'title':
-					if ( isset( $matched_level['title'], $risk_texts[ $matched_level['title'] ] ) ) {
-						$retries_chart_title = __( $risk_texts[ $matched_level['title'] ], 'limit-login-attempts-reloaded' );
+					if ( ! empty( $matched_level['title'] ) ) {
+						$retries_chart_title = $this->get_risk_circle_string( $matched_level['title'] );
 					}
 					break;
 				case 'count_title':
 					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
 					break;
 				case 'warning_title':
-					if ( isset( $risk_texts['warning_title_template'] ) ) {
-						$retries_chart_title = __( $risk_texts['warning_title_template'], 'limit-login-attempts-reloaded' );
-					}
+					$retries_chart_title = $this->get_risk_circle_string( 'warning_title_template' );
 					break;
 				case 'desc':
-					if ( isset( $matched_level['desc'], $risk_texts[ $matched_level['desc'] ] ) ) {
-						$retries_chart_desc = __( $risk_texts[ $matched_level['desc'] ], 'limit-login-attempts-reloaded' );
+					if ( ! empty( $matched_level['desc'] ) ) {
+						$retries_chart_desc = $this->get_risk_circle_string( $matched_level['desc'] );
 					}
 					break;
 				case 'recommendation':
@@ -473,8 +520,9 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
+		$this->ensure_llar_risk_config_defined();
+
 		$risk_config         = LLA_RISK_CONFIG;
-		$risk_texts          = $risk_config['texts'];
 		$risk_levels         = $risk_config['levels'];
 		$risk_colors         = $risk_config['colors'];
 		$retries_chart_title = '';
@@ -506,7 +554,7 @@ class LimitLoginAttempts
 				$retries_chart_desc = $display_data['retries_chart_desc'];
 				$retries_chart_color = $display_data['retries_chart_color'];
 			} else {
-				$retries_chart_title = __( $risk_texts['failed_today_title'], 'limit-login-attempts-reloaded' );
+				$retries_chart_title = $this->get_risk_circle_string( 'failed_today_title' );
 				$retries_chart_color = $risk_colors['green'];
 			}
 		}
@@ -1814,6 +1862,7 @@ class LimitLoginAttempts
 				$retries_stats[ $date_key ] = 1;
 			}
 			Config::update( 'retries_stats', $retries_stats );
+			$this->bust_local_retries_count_cache();
 
 			/* Check validity and add one to retries */
 			if ( isset( $retries[ $ip ] ) && isset( $valid[ $ip ] ) && time() < $valid[ $ip ] ) {
@@ -2546,6 +2595,7 @@ class LimitLoginAttempts
 			}
 
 			Config::update( 'retries_stats', $retries_stats );
+			$this->bust_local_retries_count_cache();
 		}
 
 		Config::update( 'retries', $retries );

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -414,16 +414,18 @@ class LimitLoginAttempts
 					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
 					break;
 				case 'warning_title':
-					$retries_chart_title = sprintf(
-						__( $risk_texts['warning_title_template'], 'limit-login-attempts-reloaded' ),
-						(int) $risk_config['bounds']['medium_upper']
-					);
+					$retries_chart_title = __( $risk_texts['warning_title_template'], 'limit-login-attempts-reloaded' );
 					break;
 				case 'desc':
 					$retries_chart_desc = __( $risk_texts[ $matched_level['desc'] ], 'limit-login-attempts-reloaded' );
 					break;
 				case 'recommendation':
-					$retries_chart_desc = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
+					$recommendation_html = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
+					if ( ! empty( $retries_chart_desc ) ) {
+						$retries_chart_desc .= '<br><br>' . $recommendation_html;
+					} else {
+						$retries_chart_desc = $recommendation_html;
+					}
 					break;
 				case 'premium_recommendation':
 					$retries_chart_desc = $this->get_premium_recommendation_desc( $upgrade_premium_url );

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -282,20 +282,20 @@ class LimitLoginAttempts
 	}
 
 	/**
-	 * Ensure LLA_RISK_CONFIG exists if something runs before init.
+	 * Ensure risk config is loaded (llar_get_risk_config builds once per request).
 	 *
 	 * @return void
 	 */
 	private function ensure_llar_risk_config_defined() {
-		if ( ! defined( 'LLA_RISK_CONFIG' ) && function_exists( 'llar_define_risk_config' ) ) {
-			llar_define_risk_config();
+		if ( function_exists( 'llar_get_risk_config' ) ) {
+			llar_get_risk_config();
 		}
 	}
 
 	/**
-	 * Translated string for failed-attempts circle (whitelist keys; static msgids only).
+	 * Plain-text strings for failed-attempts circle (no HTML; whitelist keys only).
 	 *
-	 * @param string $key Level text key, e.g. zero_title, desc_low, recommend_premium.
+	 * @param string $key Level text key, e.g. zero_title, desc_low.
 	 *
 	 * @return string
 	 */
@@ -309,15 +309,43 @@ class LimitLoginAttempts
 				return __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
 			case 'warning_title_template':
 				return __( 'Warning: Your site has experienced 300+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
-			case 'recommend_premium':
-				return __( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
-			case 'recommend_micro_cloud':
-				return __( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
 			case 'failed_today_title':
 				return __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
 			default:
 				return '';
 		}
+	}
+
+	/**
+	 * Recommendation HTML: Micro Cloud path (link text translated; markup built in code).
+	 *
+	 * @return string
+	 */
+	private function get_micro_cloud_recommendation_html() {
+		$before    = esc_html__( 'Based on your level of brute force activity, we recommend ', 'limit-login-attempts-reloaded' );
+		$link_text = esc_html__( 'free Micro Cloud upgrade', 'limit-login-attempts-reloaded' );
+		$after     = esc_html__( ' to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
+		$class     = esc_attr( 'button_micro_cloud' );
+		$link      = '<a class="llar_orange ' . $class . '">' . $link_text . '</a>';
+
+		return $before . $link . $after;
+	}
+
+	/**
+	 * Recommendation HTML: premium upgrade URL (href escaped; rel on external target).
+	 *
+	 * @param string $upgrade_premium_url Premium URL.
+	 *
+	 * @return string
+	 */
+	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
+		$url       = esc_url( $upgrade_premium_url );
+		$before    = esc_html__( 'Based on your level of brute force activity, we recommend ', 'limit-login-attempts-reloaded' );
+		$link_text = esc_html__( 'upgrading to premium', 'limit-login-attempts-reloaded' );
+		$after     = esc_html__( ' to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
+		$link      = '<a href="' . $url . '" class="llar_orange" target="_blank" rel="noopener noreferrer">' . $link_text . '</a>';
+
+		return $before . $link . $after;
 	}
 
 	/**
@@ -362,6 +390,31 @@ class LimitLoginAttempts
 	}
 
 	/**
+	 * Remove retries_stats buckets older than 8 days (keeps autoload option bounded).
+	 *
+	 * @param array $retries_stats Stats keyed by time bucket.
+	 *
+	 * @return array
+	 */
+	private function prune_retries_stats_old_buckets( $retries_stats ) {
+		if ( ! is_array( $retries_stats ) || empty( $retries_stats ) ) {
+			return $retries_stats;
+		}
+
+		$cutoff = strtotime( '-8 day' );
+		foreach ( $retries_stats as $key => $count ) {
+			if (
+				( is_numeric( $key ) && (int) $key < $cutoff )
+				|| ( ! is_numeric( $key ) && strtotime( $key ) < $cutoff )
+			) {
+				unset( $retries_stats[ $key ] );
+			}
+		}
+
+		return $retries_stats;
+	}
+
+	/**
 	 * Build localized retries chart title with attempts count.
 	 *
 	 * @param int $retries_count Number of retries.
@@ -371,8 +424,8 @@ class LimitLoginAttempts
 	private function get_retries_chart_title_with_count( $retries_count ) {
 		return sprintf(
 			_n(
-				__( '%d failed login attempt ', 'limit-login-attempts-reloaded' ),
-				__( '%d failed login attempts ', 'limit-login-attempts-reloaded' ),
+				'%d failed login attempt ',
+				'%d failed login attempts ',
 				$retries_count,
 				'limit-login-attempts-reloaded'
 			),
@@ -393,24 +446,7 @@ class LimitLoginAttempts
 			return $this->get_premium_recommendation_desc( $upgrade_premium_url );
 		}
 
-		return sprintf(
-			$this->get_risk_circle_string( 'recommend_micro_cloud' ),
-			esc_attr( 'button_micro_cloud' )
-		);
-	}
-
-	/**
-	 * Build recommendation description with premium upgrade link.
-	 *
-	 * @param string $upgrade_premium_url Premium upgrade URL.
-	 *
-	 * @return string
-	 */
-	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
-		return sprintf(
-			$this->get_risk_circle_string( 'recommend_premium' ),
-			esc_url( $upgrade_premium_url )
-		);
+		return $this->get_micro_cloud_recommendation_html();
 	}
 
 	/**
@@ -522,7 +558,7 @@ class LimitLoginAttempts
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
 		$this->ensure_llar_risk_config_defined();
 
-		$risk_config         = LLA_RISK_CONFIG;
+		$risk_config         = llar_get_risk_config();
 		$risk_levels         = $risk_config['levels'];
 		$risk_colors         = $risk_config['colors'];
 		$retries_chart_title = '';
@@ -540,7 +576,7 @@ class LimitLoginAttempts
 			$retries_chart_color = $display_data['retries_chart_color'];
 		} else {
 			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) && is_array( $api_stats['attempts']['count'] ) ) {
-				$attempt_counts = $api_stats['attempts']['count'];
+				$attempt_counts = array_values( $api_stats['attempts']['count'] );
 				$n = count( $attempt_counts );
 				if ( $n > 0 ) {
 					$retries_count = (int) $attempt_counts[ $n - 1 ];
@@ -1861,6 +1897,7 @@ class LimitLoginAttempts
 
 				$retries_stats[ $date_key ] = 1;
 			}
+			$retries_stats = $this->prune_retries_stats_old_buckets( $retries_stats );
 			Config::update( 'retries_stats', $retries_stats );
 			$this->bust_local_retries_count_cache();
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -312,9 +312,9 @@ class LimitLoginAttempts
 			case 'zero_title':
 				return __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
 			case 'desc_low':
-				return __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
+				return __( 'Your site is currently at a low risk for brute force activity.', 'limit-login-attempts-reloaded' );
 			case 'desc_medium':
-				return __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
+				return __( 'Your site is currently at a medium risk for brute force activity.', 'limit-login-attempts-reloaded' );
 			case 'failed_today_title':
 				return __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
 			default:
@@ -518,9 +518,9 @@ class LimitLoginAttempts
 					if ( isset( $risk_config['bounds']['medium_upper'] ) ) {
 						$medium_upper = (int) $risk_config['bounds']['medium_upper'];
 					}
-					/* translators: %d: threshold count (e.g. 300) for "N+ failed login attempts". */
+					/* translators: %d: threshold count (e.g. 300) for "N+ failed login attempts" (high risk, local mode). */
 					$retries_chart_title = sprintf(
-						__( 'Warning: Your site has experienced %d+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' ),
+						__( 'Your site has experienced %d+ failed login attempts in the past 24 hours.', 'limit-login-attempts-reloaded' ),
 						$medium_upper
 					);
 					break;
@@ -558,9 +558,12 @@ class LimitLoginAttempts
 	/**
 	 * Build data for failed attempts circle widget.
 	 *
+	 * Local mode: risk color bands by retries (0 / 1–99 / 100–299 / 300+). Custom Cloud: always green
+	 * indicator; retries count only (no risk band styling).
+	 *
 	 * @param bool        $is_active_app_custom Cloud mode flag.
-	 * @param bool|string $is_exhausted         Cloud exhausted flag.
-	 * @param string      $block_sub_group      Cloud plan name.
+	 * @param bool|string $is_exhausted         Cloud exhausted flag (unused for donut styling; kept for callers).
+	 * @param string      $block_sub_group      Cloud plan name (unused for donut styling; kept for callers).
 	 * @param string      $setup_code           App setup code.
 	 * @param string      $upgrade_premium_url  Premium upgrade URL.
 	 * @param bool|array  $api_stats            Cloud API stats.
@@ -586,6 +589,7 @@ class LimitLoginAttempts
 			$retries_chart_desc = $display_data['retries_chart_desc'];
 			$retries_chart_color = $display_data['retries_chart_color'];
 		} else {
+			// Custom Cloud: always green "no risk" indicator; show retries count only (product spec).
 			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) && is_array( $api_stats['attempts']['count'] ) ) {
 				$attempt_counts = array();
 				foreach ( $api_stats['attempts']['count'] as $v ) {
@@ -598,17 +602,9 @@ class LimitLoginAttempts
 				}
 			}
 
-			if ( $is_exhausted && 'Micro Cloud' === $block_sub_group ) {
-				$cloud_levels  = isset( $risk_levels['cloud_exhausted_micro'] ) && is_array( $risk_levels['cloud_exhausted_micro'] ) ? $risk_levels['cloud_exhausted_micro'] : array();
-				$matched_level = $this->resolve_risk_level( $retries_count, $cloud_levels );
-				$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
-				$retries_chart_title = $display_data['retries_chart_title'];
-				$retries_chart_desc = $display_data['retries_chart_desc'];
-				$retries_chart_color = $display_data['retries_chart_color'];
-			} else {
-				$retries_chart_title = $this->get_risk_circle_string( 'failed_today_title' );
-				$retries_chart_color = isset( $risk_colors['green'] ) ? $risk_colors['green'] : '#97F6C8';
-			}
+			$retries_chart_title = $this->get_risk_circle_string( 'failed_today_title' );
+			$retries_chart_desc  = '';
+			$retries_chart_color = isset( $risk_colors['green'] ) ? $risk_colors['green'] : '#97F6C8';
 		}
 
 		return array(

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -350,7 +350,7 @@ class LimitLoginAttempts
 		if ( $open_new_window ) {
 			return sprintf(
 				__(
-					'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.',
+					'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank" rel="noopener noreferrer">upgrading to premium</a> to access features to reduce failed logins and improve site performance.',
 					'limit-login-attempts-reloaded'
 				),
 				$url
@@ -440,7 +440,7 @@ class LimitLoginAttempts
 	 */
 	private function get_recommendation_desc( $setup_code, $upgrade_premium_url ) {
 		if ( ! empty( $setup_code ) ) {
-			$premium_tab_url = admin_url( 'admin.php?page=' . $this->_options_page_slug . '&tab=premium' );
+			$premium_tab_url = $this->get_options_page_uri( 'premium' );
 			return $this->get_premium_recommendation_desc( $premium_tab_url, false );
 		}
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -499,8 +499,16 @@ class LimitLoginAttempts
 		$retries_chart_desc = '';
 		$retries_chart_color = $default_color;
 
+		$rule_flag_keys = array( 'count_title', 'warning_title', 'recommendation', 'premium_recommendation' );
 		foreach ( array( 'title', 'count_title', 'warning_title', 'desc', 'recommendation', 'premium_recommendation', 'color' ) as $rule_key ) {
-			if ( empty( $matched_level[ $rule_key ] ) ) {
+			if ( ! isset( $matched_level[ $rule_key ] ) ) {
+				continue;
+			}
+			if ( in_array( $rule_key, $rule_flag_keys, true ) ) {
+				if ( true !== $matched_level[ $rule_key ] && ! $matched_level[ $rule_key ] ) {
+					continue;
+				}
+			} elseif ( empty( $matched_level[ $rule_key ] ) ) {
 				continue;
 			}
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -282,6 +282,157 @@ class LimitLoginAttempts
 	}
 
 	/**
+	 * Get failed login attempts count for the last 24 hours in local mode.
+	 *
+	 * @return int
+	 */
+	public function get_local_retries_count_for_last_day() {
+		$retries_count = 0;
+		$retries_stats = Config::get( 'retries_stats' );
+
+		if ( $retries_stats ) {
+			foreach ( $retries_stats as $key => $count ) {
+				if ( is_numeric( $key ) && strtotime( '-24 hours' ) < $key ) {
+					$retries_count += $count;
+				} elseif ( ! is_numeric( $key ) && date_i18n( 'Y-m-d' ) === $key ) {
+					$retries_count += $count;
+				}
+			}
+		}
+
+		return (int) $retries_count;
+	}
+
+	/**
+	 * Build localized retries chart title with attempts count.
+	 *
+	 * @param int $retries_count Number of retries.
+	 *
+	 * @return string
+	 */
+	private function get_retries_chart_title_with_count( $retries_count ) {
+		return sprintf(
+			_n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ),
+			$retries_count
+		) . __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
+	}
+
+	/**
+	 * Build recommendation description for elevated brute force activity.
+	 *
+	 * @param string $setup_code          App setup code.
+	 * @param string $upgrade_premium_url Premium upgrade URL.
+	 *
+	 * @return string
+	 */
+	private function get_recommendation_desc( $setup_code, $upgrade_premium_url ) {
+		if ( ! empty( $setup_code ) ) {
+			return $this->get_premium_recommendation_desc( $upgrade_premium_url );
+		}
+
+		return sprintf(
+			__( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
+			'button_micro_cloud'
+		);
+	}
+
+	/**
+	 * Build recommendation description with premium upgrade link.
+	 *
+	 * @param string $upgrade_premium_url Premium upgrade URL.
+	 *
+	 * @return string
+	 */
+	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
+		return sprintf(
+			__( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
+			$upgrade_premium_url
+		);
+	}
+
+	/**
+	 * Build data for failed attempts circle widget.
+	 *
+	 * @param bool        $is_active_app_custom Cloud mode flag.
+	 * @param bool|string $is_exhausted         Cloud exhausted flag.
+	 * @param string      $block_sub_group      Cloud plan name.
+	 * @param string      $setup_code           App setup code.
+	 * @param string      $upgrade_premium_url  Premium upgrade URL.
+	 * @param bool|array  $api_stats            Cloud API stats.
+	 *
+	 * @return array
+	 */
+	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
+		$retries_chart_title = '';
+		$retries_chart_desc  = '';
+		$retries_chart_color = '';
+		$retries_count       = 0;
+
+		if ( ! $is_active_app_custom ) {
+			$retries_count = $this->get_local_retries_count_for_last_day();
+
+			switch ( true ) {
+				case 0 === $retries_count:
+					$retries_chart_title = __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
+					$retries_chart_color = '#97F6C8';
+					break;
+				case 100 > $retries_count:
+					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
+					$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
+					$retries_chart_color = '#FFE066';
+					break;
+				case 300 > $retries_count:
+					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
+					$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
+					$retries_chart_color = '#FFCC66';
+					break;
+				case 500 > $retries_count:
+					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
+					$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
+					$retries_chart_color = '#FF4D4F';
+					break;
+				default:
+					$retries_chart_title = __( 'Warning: Your site has experienced over 500 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
+					$retries_chart_desc = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
+					$retries_chart_color = '#FF6633';
+					break;
+			}
+		} else {
+			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) ) {
+				$retries_count = (int) end( $api_stats['attempts']['count'] );
+			}
+
+			if ( $is_exhausted && 'Micro Cloud' === $block_sub_group ) {
+				switch ( true ) {
+					case 0 === $retries_count:
+						$retries_chart_title = __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
+						$retries_chart_color = '#97F6C8';
+						break;
+					case 100 > $retries_count:
+						$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
+						$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
+						$retries_chart_color = '#FFCC66';
+						break;
+					default:
+						$retries_chart_desc = $this->get_premium_recommendation_desc( $upgrade_premium_url );
+						$retries_chart_color = '#FF6633';
+						break;
+				}
+			} else {
+				$retries_chart_title = __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
+				$retries_chart_color = '#97F6C8';
+			}
+		}
+
+		return array(
+			'retries_chart_title' => $retries_chart_title,
+			'retries_chart_desc'  => $retries_chart_desc,
+			'retries_chart_color' => $retries_chart_color,
+			'retries_count'       => (int) $retries_count,
+		);
+	}
+
+	/**
 	 * Redirect to dashboard page after installed
 	 */
 	public function dashboard_page_redirect()

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -456,8 +456,6 @@ class LimitLoginAttempts
 	 * @param bool|array  $api_stats            Cloud API stats.
 	 *
 	 * @return array
-	 *
-	 * QA: use LLA_RISK_CIRCLE_CONFIG_JSON in wp-config.php (see llar_define_risk_config) or legacy LLA_DEBUG_CHART_RETRIES.
 	 */
 	public function get_failed_attempts_circle_data( $is_active_app_custom, $is_exhausted, $block_sub_group, $setup_code, $upgrade_premium_url, $api_stats ) {
 		$risk_config         = LLA_RISK_CONFIG;
@@ -470,12 +468,7 @@ class LimitLoginAttempts
 		$retries_count       = 0;
 
 		if ( ! $is_active_app_custom ) {
-			$retries_raw   = $this->get_local_retries_count_for_last_day();
-			$retries_count = $retries_raw;
-			$qa_force        = llar_risk_qa_force_retries();
-			if ( null !== $qa_force ) {
-				$retries_count = $qa_force;
-			}
+			$retries_count = $this->get_local_retries_count_for_last_day();
 
 			$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['local'] );
 			$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
@@ -497,24 +490,6 @@ class LimitLoginAttempts
 				$retries_chart_title = __( $risk_texts['failed_today_title'], 'limit-login-attempts-reloaded' );
 				$retries_chart_color = $risk_colors['green'];
 			}
-		}
-
-		// QA: optional local risk display (count + color/title/desc) when Cloud App would otherwise show green cloud copy.
-		if ( llar_risk_qa_force_local_risk_ui() ) {
-			$qa_force = llar_risk_qa_force_retries();
-			if ( null !== $qa_force ) {
-				$retries_count = $qa_force;
-				$matched_level = $this->resolve_risk_level( $retries_count, $risk_levels['local'] );
-				$display_data = $this->build_chart_display_data( $matched_level, $retries_count, $risk_config, $setup_code, $upgrade_premium_url );
-				$retries_chart_title = $display_data['retries_chart_title'];
-				$retries_chart_desc = $display_data['retries_chart_desc'];
-				$retries_chart_color = $display_data['retries_chart_color'];
-			}
-		}
-
-		$qa_force_final = llar_risk_qa_force_retries();
-		if ( null !== $qa_force_final ) {
-			$retries_count = $qa_force_final;
 		}
 
 		return array(

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -291,8 +291,9 @@ class LimitLoginAttempts
 		$retries_stats = Config::get( 'retries_stats' );
 
 		if ( $retries_stats ) {
+			$cutoff_ts = current_time( 'timestamp' ) - DAY_IN_SECONDS;
 			foreach ( $retries_stats as $key => $count ) {
-				if ( is_numeric( $key ) && strtotime( '-24 hours' ) < $key ) {
+				if ( is_numeric( $key ) && (int) $key > $cutoff_ts ) {
 					$retries_count += $count;
 				} elseif ( ! is_numeric( $key ) && date_i18n( 'Y-m-d' ) === $key ) {
 					$retries_count += $count;
@@ -312,11 +313,14 @@ class LimitLoginAttempts
 	 */
 	private function get_retries_chart_title_with_count( $retries_count ) {
 		$risk_texts = LLA_RISK_CONFIG['texts'];
+		$single     = isset( $risk_texts['count_attempt_single'] ) ? $risk_texts['count_attempt_single'] : '';
+		$plural     = isset( $risk_texts['count_attempt_plural'] ) ? $risk_texts['count_attempt_plural'] : '';
+		$suffix     = isset( $risk_texts['count_attempt_suffix'] ) ? $risk_texts['count_attempt_suffix'] : '';
 
 		return sprintf(
-			_n( $risk_texts['count_attempt_single'], $risk_texts['count_attempt_plural'], $retries_count, 'limit-login-attempts-reloaded' ),
+			_n( $single, $plural, $retries_count, 'limit-login-attempts-reloaded' ),
 			$retries_count
-		) . __( $risk_texts['count_attempt_suffix'], 'limit-login-attempts-reloaded' );
+		) . __( $suffix, 'limit-login-attempts-reloaded' );
 	}
 
 	/**
@@ -334,8 +338,10 @@ class LimitLoginAttempts
 			return $this->get_premium_recommendation_desc( $upgrade_premium_url );
 		}
 
+		$template = isset( $risk_texts['recommend_micro_cloud'] ) ? $risk_texts['recommend_micro_cloud'] : '';
+
 		return sprintf(
-			__( $risk_texts['recommend_micro_cloud'], 'limit-login-attempts-reloaded' ),
+			__( $template, 'limit-login-attempts-reloaded' ),
 			'button_micro_cloud'
 		);
 	}
@@ -349,10 +355,11 @@ class LimitLoginAttempts
 	 */
 	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
 		$risk_texts = LLA_RISK_CONFIG['texts'];
+		$template   = isset( $risk_texts['recommend_premium'] ) ? $risk_texts['recommend_premium'] : '';
 
 		return sprintf(
-			__( $risk_texts['recommend_premium'], 'limit-login-attempts-reloaded' ),
-			$upgrade_premium_url
+			__( $template, 'limit-login-attempts-reloaded' ),
+			esc_url( $upgrade_premium_url )
 		);
 	}
 
@@ -365,6 +372,8 @@ class LimitLoginAttempts
 	 * @return array
 	 */
 	private function resolve_risk_level( $retries_count, $levels ) {
+		$default_level = null;
+
 		foreach ( $levels as $level ) {
 			if ( isset( $level['exact'] ) && (int) $level['exact'] === $retries_count ) {
 				return $level;
@@ -375,11 +384,11 @@ class LimitLoginAttempts
 			}
 
 			if ( ! empty( $level['default'] ) ) {
-				return $level;
+				$default_level = $level;
 			}
 		}
 
-		return array();
+		return null !== $default_level ? $default_level : array();
 	}
 
 	/**
@@ -408,16 +417,22 @@ class LimitLoginAttempts
 
 			switch ( $rule_key ) {
 				case 'title':
-					$retries_chart_title = __( $risk_texts[ $matched_level['title'] ], 'limit-login-attempts-reloaded' );
+					if ( isset( $matched_level['title'], $risk_texts[ $matched_level['title'] ] ) ) {
+						$retries_chart_title = __( $risk_texts[ $matched_level['title'] ], 'limit-login-attempts-reloaded' );
+					}
 					break;
 				case 'count_title':
 					$retries_chart_title = $this->get_retries_chart_title_with_count( $retries_count );
 					break;
 				case 'warning_title':
-					$retries_chart_title = __( $risk_texts['warning_title_template'], 'limit-login-attempts-reloaded' );
+					if ( isset( $risk_texts['warning_title_template'] ) ) {
+						$retries_chart_title = __( $risk_texts['warning_title_template'], 'limit-login-attempts-reloaded' );
+					}
 					break;
 				case 'desc':
-					$retries_chart_desc = __( $risk_texts[ $matched_level['desc'] ], 'limit-login-attempts-reloaded' );
+					if ( isset( $matched_level['desc'], $risk_texts[ $matched_level['desc'] ] ) ) {
+						$retries_chart_desc = __( $risk_texts[ $matched_level['desc'] ], 'limit-login-attempts-reloaded' );
+					}
 					break;
 				case 'recommendation':
 					$recommendation_html = $this->get_recommendation_desc( $setup_code, $upgrade_premium_url );
@@ -476,8 +491,12 @@ class LimitLoginAttempts
 			$retries_chart_desc = $display_data['retries_chart_desc'];
 			$retries_chart_color = $display_data['retries_chart_color'];
 		} else {
-			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) ) {
-				$retries_count = (int) end( $api_stats['attempts']['count'] );
+			if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) && is_array( $api_stats['attempts']['count'] ) ) {
+				$attempt_counts = $api_stats['attempts']['count'];
+				$n = count( $attempt_counts );
+				if ( $n > 0 ) {
+					$retries_count = (int) $attempt_counts[ $n - 1 ];
+				}
 			}
 
 			if ( $is_exhausted && 'Micro Cloud' === $block_sub_group ) {

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -328,30 +328,42 @@ class LimitLoginAttempts
 	 * @return string
 	 */
 	private function get_micro_cloud_recommendation_html() {
-		$before    = esc_html__( 'Based on your level of brute force activity, we recommend ', 'limit-login-attempts-reloaded' );
-		$link_text = esc_html__( 'free Micro Cloud upgrade', 'limit-login-attempts-reloaded' );
-		$after     = esc_html__( ' to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
-		$class     = esc_attr( 'button_micro_cloud' );
-		$link      = '<a class="llar_orange ' . $class . '">' . $link_text . '</a>';
-
-		return $before . $link . $after;
+		return sprintf(
+			__(
+				'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.',
+				'limit-login-attempts-reloaded'
+			),
+			'button_micro_cloud'
+		);
 	}
 
 	/**
 	 * Recommendation HTML: premium upgrade URL (href escaped; rel on external target).
 	 *
 	 * @param string $upgrade_premium_url Premium URL.
+	 * @param bool   $open_new_window     Open link in a new window.
 	 *
 	 * @return string
 	 */
-	private function get_premium_recommendation_desc( $upgrade_premium_url ) {
+	private function get_premium_recommendation_desc( $upgrade_premium_url, $open_new_window = true ) {
 		$url       = esc_url( $upgrade_premium_url );
-		$before    = esc_html__( 'Based on your level of brute force activity, we recommend ', 'limit-login-attempts-reloaded' );
-		$link_text = esc_html__( 'upgrading to premium', 'limit-login-attempts-reloaded' );
-		$after     = esc_html__( ' to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' );
-		$link      = '<a href="' . $url . '" class="llar_orange" target="_blank" rel="noopener noreferrer">' . $link_text . '</a>';
+		if ( $open_new_window ) {
+			return sprintf(
+				__(
+					'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.',
+					'limit-login-attempts-reloaded'
+				),
+				$url
+			);
+		}
 
-		return $before . $link . $after;
+		return sprintf(
+			__(
+				'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange">upgrading to premium</a> to access features to reduce failed logins and improve site performance.',
+				'limit-login-attempts-reloaded'
+			),
+			$url
+		);
 	}
 
 	/**
@@ -428,7 +440,8 @@ class LimitLoginAttempts
 	 */
 	private function get_recommendation_desc( $setup_code, $upgrade_premium_url ) {
 		if ( ! empty( $setup_code ) ) {
-			return $this->get_premium_recommendation_desc( $upgrade_premium_url );
+			$premium_tab_url = admin_url( 'admin.php?page=' . $this->_options_page_slug . '&tab=premium' );
+			return $this->get_premium_recommendation_desc( $premium_tab_url, false );
 		}
 
 		return $this->get_micro_cloud_recommendation_html();

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -21,12 +21,18 @@ define( 'LLA_PLUGIN_FILE', __FILE__ );
 define( 'LLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 /**
- * Define risk widget config after i18n is ready.
+ * Risk widget config (colors, level rules). Not a global define — avoids pre-init overrides.
  *
- * @return void
+ * @return array
  */
-function llar_define_risk_config() {
-	$config = array(
+function llar_get_risk_config() {
+	static $cached = null;
+
+	if ( null !== $cached ) {
+		return $cached;
+	}
+
+	$cached = array(
 		'bounds' => array(
 			'low_upper'    => 100,
 			'medium_upper' => 300,
@@ -52,7 +58,16 @@ function llar_define_risk_config() {
 		),
 	);
 
-	define( 'LLA_RISK_CONFIG', $config );
+	return $cached;
+}
+
+/**
+ * Warm risk config on init (after translations load).
+ *
+ * @return void
+ */
+function llar_define_risk_config() {
+	llar_get_risk_config();
 }
 
 add_action( 'init', 'llar_define_risk_config', 1 );

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -19,13 +19,87 @@ define( 'LLA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'LLA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LLA_PLUGIN_FILE', __FILE__ );
 define( 'LLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
+/**
+ * Merge JSON override into base failed-attempts risk config (bounds, colors, texts, levels, qa).
+ *
+ * @param array $base     Base config.
+ * @param array $override Decoded JSON (partial).
+ *
+ * @return array
+ */
+function llar_risk_config_merge_override( $base, $override ) {
+	if ( ! is_array( $override ) ) {
+		return $base;
+	}
+
+	foreach ( array( 'bounds', 'colors', 'texts' ) as $key ) {
+		if ( isset( $override[ $key ] ) && is_array( $override[ $key ] ) ) {
+			$base[ $key ] = array_merge( $base[ $key ], $override[ $key ] );
+		}
+	}
+
+	if ( isset( $override['levels'] ) && is_array( $override['levels'] ) ) {
+		foreach ( $override['levels'] as $level_key => $level_val ) {
+			if ( is_array( $level_val ) ) {
+				$base['levels'][ $level_key ] = $level_val;
+			}
+		}
+	}
+
+	if ( isset( $override['qa'] ) && is_array( $override['qa'] ) ) {
+		$base['qa'] = array_merge( $base['qa'], $override['qa'] );
+	}
+
+	return $base;
+}
+
+/**
+ * QA: forced retries count from LLA_RISK_CONFIG['qa'] (set via LLA_RISK_CIRCLE_CONFIG_JSON or legacy LLA_DEBUG_CHART_RETRIES).
+ *
+ * @return int|null Null if not forcing.
+ */
+function llar_risk_qa_force_retries() {
+	if ( ! defined( 'LLA_RISK_CONFIG' ) ) {
+		return null;
+	}
+
+	$qa = isset( LLA_RISK_CONFIG['qa'] ) ? LLA_RISK_CONFIG['qa'] : array();
+	if ( array_key_exists( 'force_retries_count', $qa ) && is_numeric( $qa['force_retries_count'] ) ) {
+		return (int) $qa['force_retries_count'];
+	}
+
+	return null;
+}
+
+/**
+ * QA: when forcing retries, rebuild title/desc/color from local risk levels (e.g. Cloud App on).
+ *
+ * @return bool
+ */
+function llar_risk_qa_force_local_risk_ui() {
+	if ( null === llar_risk_qa_force_retries() ) {
+		return false;
+	}
+
+	$qa = defined( 'LLA_RISK_CONFIG' ) && isset( LLA_RISK_CONFIG['qa'] ) ? LLA_RISK_CONFIG['qa'] : array();
+	if ( isset( $qa['force_local_risk_ui'] ) ) {
+		return (bool) $qa['force_local_risk_ui'];
+	}
+
+	return true;
+}
+
 /**
  * Define risk widget config after i18n is ready.
+ *
+ * Optional: define LLA_RISK_CIRCLE_CONFIG_JSON in wp-config.php as a JSON string (see plugin docs).
+ * Legacy: LLA_DEBUG_CHART_RETRIES still sets qa.force_retries_count after merge.
  *
  * @return void
  */
 function llar_define_risk_config() {
-	define( 'LLA_RISK_CONFIG', array(
+	$config = array(
 		'bounds' => array(
 			'low_upper'    => 100,
 			'medium_upper' => 300,
@@ -61,7 +135,24 @@ function llar_define_risk_config() {
 				array( 'default' => true, 'premium_recommendation' => true, 'color' => 'red' ),
 			),
 		),
-	) );
+		'qa' => array(
+			'force_retries_count'  => null,
+			'force_local_risk_ui'  => true,
+		),
+	);
+
+	if ( defined( 'LLA_RISK_CIRCLE_CONFIG_JSON' ) && is_string( LLA_RISK_CIRCLE_CONFIG_JSON ) && '' !== LLA_RISK_CIRCLE_CONFIG_JSON ) {
+		$decoded = json_decode( LLA_RISK_CIRCLE_CONFIG_JSON, true );
+		if ( is_array( $decoded ) ) {
+			$config = llar_risk_config_merge_override( $config, $decoded );
+		}
+	}
+
+	if ( defined( 'LLA_DEBUG_CHART_RETRIES' ) ) {
+		$config['qa']['force_retries_count'] = (int) LLA_DEBUG_CHART_RETRIES;
+	}
+
+	define( 'LLA_RISK_CONFIG', $config );
 }
 
 add_action( 'init', 'llar_define_risk_config', 1 );

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -56,6 +56,7 @@ function llar_get_risk_config_defaults() {
 					'max_exclusive'  => 300,
 					'count_title'    => true,
 					'desc'           => 'desc_medium',
+					/* Same recommendation block as high (red); threshold moved to 300+. */
 					'recommendation' => true,
 					'color'          => 'orange',
 				),

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -37,18 +37,6 @@ function llar_define_risk_config() {
 			'orange' => '#FFCC66',
 			'red'    => '#FF6633',
 		),
-		'texts' => array(
-			'zero_title'             => __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' ),
-			'count_attempt_single'   => __( '%d failed login attempt ', 'limit-login-attempts-reloaded' ),
-			'count_attempt_plural'   => __( '%d failed login attempts ', 'limit-login-attempts-reloaded' ),
-			'count_attempt_suffix'   => __( '(past 24 hrs)', 'limit-login-attempts-reloaded' ),
-			'desc_low'               => __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' ),
-			'desc_medium'            => __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' ),
-			'warning_title_template' => __( 'Warning: Your site has experienced 300+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' ),
-			'recommend_premium'      => __( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
-			'recommend_micro_cloud'  => __( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
-			'failed_today_title'     => __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' ),
-		),
 		'levels' => array(
 			'local' => array(
 				array( 'exact' => 0, 'title' => 'zero_title', 'color' => 'green' ),

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -61,28 +61,11 @@ function llar_get_risk_config_defaults() {
 					'color'          => 'orange',
 				),
 				array(
+					'min_inclusive'  => 300,
 					'default'        => true,
 					'warning_title'  => true,
 					'recommendation' => true,
 					'color'          => 'red',
-				),
-			),
-			'cloud_exhausted_micro' => array(
-				array(
-					'exact' => 0,
-					'title' => 'zero_title',
-					'color' => 'green',
-				),
-				array(
-					'max_exclusive' => 100,
-					'count_title'   => true,
-					'desc'          => 'desc_low',
-					'color'         => 'orange',
-				),
-				array(
-					'default'                => true,
-					'premium_recommendation' => true,
-					'color'                  => 'red',
 				),
 			),
 		),
@@ -111,9 +94,6 @@ function llar_normalize_risk_config( $defaults, $cfg ) {
 
 	if ( ! isset( $out['levels']['local'] ) || ! is_array( $out['levels']['local'] ) ) {
 		$out['levels']['local'] = $defaults['levels']['local'];
-	}
-	if ( ! isset( $out['levels']['cloud_exhausted_micro'] ) || ! is_array( $out['levels']['cloud_exhausted_micro'] ) ) {
-		$out['levels']['cloud_exhausted_micro'] = $defaults['levels']['cloud_exhausted_micro'];
 	}
 
 	return $out;

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -43,7 +43,7 @@ function llar_define_risk_config() {
 			'count_attempt_suffix'   => __( '(past 24 hrs)', 'limit-login-attempts-reloaded' ),
 			'desc_low'               => __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' ),
 			'desc_medium'            => __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' ),
-			'warning_title_template' => __( 'Warning: Your site has experienced over %d failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' ),
+			'warning_title_template' => __( 'Warning: Your site has experienced 300+ failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' ),
 			'recommend_premium'      => __( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
 			'recommend_micro_cloud'  => __( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
 			'failed_today_title'     => __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' ),
@@ -52,7 +52,7 @@ function llar_define_risk_config() {
 			'local' => array(
 				array( 'exact' => 0, 'title' => 'zero_title', 'color' => 'green' ),
 				array( 'max_exclusive' => 100, 'count_title' => true, 'desc' => 'desc_low', 'color' => 'yellow' ),
-				array( 'max_exclusive' => 300, 'count_title' => true, 'desc' => 'desc_medium', 'color' => 'orange' ),
+				array( 'max_exclusive' => 300, 'count_title' => true, 'desc' => 'desc_medium', 'recommendation' => true, 'color' => 'orange' ),
 				array( 'default' => true, 'warning_title' => true, 'recommendation' => true, 'color' => 'red' ),
 			),
 			'cloud_exhausted_micro' => array(

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -21,80 +21,7 @@ define( 'LLA_PLUGIN_FILE', __FILE__ );
 define( 'LLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 /**
- * Merge JSON override into base failed-attempts risk config (bounds, colors, texts, levels, qa).
- *
- * @param array $base     Base config.
- * @param array $override Decoded JSON (partial).
- *
- * @return array
- */
-function llar_risk_config_merge_override( $base, $override ) {
-	if ( ! is_array( $override ) ) {
-		return $base;
-	}
-
-	foreach ( array( 'bounds', 'colors', 'texts' ) as $key ) {
-		if ( isset( $override[ $key ] ) && is_array( $override[ $key ] ) ) {
-			$base[ $key ] = array_merge( $base[ $key ], $override[ $key ] );
-		}
-	}
-
-	if ( isset( $override['levels'] ) && is_array( $override['levels'] ) ) {
-		foreach ( $override['levels'] as $level_key => $level_val ) {
-			if ( is_array( $level_val ) ) {
-				$base['levels'][ $level_key ] = $level_val;
-			}
-		}
-	}
-
-	if ( isset( $override['qa'] ) && is_array( $override['qa'] ) ) {
-		$base['qa'] = array_merge( $base['qa'], $override['qa'] );
-	}
-
-	return $base;
-}
-
-/**
- * QA: forced retries count from LLA_RISK_CONFIG['qa'] (set via LLA_RISK_CIRCLE_CONFIG_JSON or legacy LLA_DEBUG_CHART_RETRIES).
- *
- * @return int|null Null if not forcing.
- */
-function llar_risk_qa_force_retries() {
-	if ( ! defined( 'LLA_RISK_CONFIG' ) ) {
-		return null;
-	}
-
-	$qa = isset( LLA_RISK_CONFIG['qa'] ) ? LLA_RISK_CONFIG['qa'] : array();
-	if ( array_key_exists( 'force_retries_count', $qa ) && is_numeric( $qa['force_retries_count'] ) ) {
-		return (int) $qa['force_retries_count'];
-	}
-
-	return null;
-}
-
-/**
- * QA: when forcing retries, rebuild title/desc/color from local risk levels (e.g. Cloud App on).
- *
- * @return bool
- */
-function llar_risk_qa_force_local_risk_ui() {
-	if ( null === llar_risk_qa_force_retries() ) {
-		return false;
-	}
-
-	$qa = defined( 'LLA_RISK_CONFIG' ) && isset( LLA_RISK_CONFIG['qa'] ) ? LLA_RISK_CONFIG['qa'] : array();
-	if ( isset( $qa['force_local_risk_ui'] ) ) {
-		return (bool) $qa['force_local_risk_ui'];
-	}
-
-	return true;
-}
-
-/**
  * Define risk widget config after i18n is ready.
- *
- * Optional: define LLA_RISK_CIRCLE_CONFIG_JSON in wp-config.php as a JSON string (see plugin docs).
- * Legacy: LLA_DEBUG_CHART_RETRIES still sets qa.force_retries_count after merge.
  *
  * @return void
  */
@@ -135,22 +62,7 @@ function llar_define_risk_config() {
 				array( 'default' => true, 'premium_recommendation' => true, 'color' => 'red' ),
 			),
 		),
-		'qa' => array(
-			'force_retries_count'  => null,
-			'force_local_risk_ui'  => true,
-		),
 	);
-
-	if ( defined( 'LLA_RISK_CIRCLE_CONFIG_JSON' ) && is_string( LLA_RISK_CIRCLE_CONFIG_JSON ) && '' !== LLA_RISK_CIRCLE_CONFIG_JSON ) {
-		$decoded = json_decode( LLA_RISK_CIRCLE_CONFIG_JSON, true );
-		if ( is_array( $decoded ) ) {
-			$config = llar_risk_config_merge_override( $config, $decoded );
-		}
-	}
-
-	if ( defined( 'LLA_DEBUG_CHART_RETRIES' ) ) {
-		$config['qa']['force_retries_count'] = (int) LLA_DEBUG_CHART_RETRIES;
-	}
 
 	define( 'LLA_RISK_CONFIG', $config );
 }

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -19,6 +19,52 @@ define( 'LLA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'LLA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LLA_PLUGIN_FILE', __FILE__ );
 define( 'LLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+/**
+ * Define risk widget config after i18n is ready.
+ *
+ * @return void
+ */
+function llar_define_risk_config() {
+	define( 'LLA_RISK_CONFIG', array(
+		'bounds' => array(
+			'low_upper'    => 100,
+			'medium_upper' => 300,
+		),
+		'colors' => array(
+			'green'  => '#97F6C8',
+			'yellow' => '#FFE066',
+			'orange' => '#FFCC66',
+			'red'    => '#FF6633',
+		),
+		'texts' => array(
+			'zero_title'             => __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' ),
+			'count_attempt_single'   => __( '%d failed login attempt ', 'limit-login-attempts-reloaded' ),
+			'count_attempt_plural'   => __( '%d failed login attempts ', 'limit-login-attempts-reloaded' ),
+			'count_attempt_suffix'   => __( '(past 24 hrs)', 'limit-login-attempts-reloaded' ),
+			'desc_low'               => __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' ),
+			'desc_medium'            => __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' ),
+			'warning_title_template' => __( 'Warning: Your site has experienced over %d failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' ),
+			'recommend_premium'      => __( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
+			'recommend_micro_cloud'  => __( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
+			'failed_today_title'     => __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' ),
+		),
+		'levels' => array(
+			'local' => array(
+				array( 'exact' => 0, 'title' => 'zero_title', 'color' => 'green' ),
+				array( 'max_exclusive' => 100, 'count_title' => true, 'desc' => 'desc_low', 'color' => 'yellow' ),
+				array( 'max_exclusive' => 300, 'count_title' => true, 'desc' => 'desc_medium', 'color' => 'orange' ),
+				array( 'default' => true, 'warning_title' => true, 'recommendation' => true, 'color' => 'red' ),
+			),
+			'cloud_exhausted_micro' => array(
+				array( 'exact' => 0, 'title' => 'zero_title', 'color' => 'green' ),
+				array( 'max_exclusive' => 100, 'count_title' => true, 'desc' => 'desc_low', 'color' => 'orange' ),
+				array( 'default' => true, 'premium_recommendation' => true, 'color' => 'red' ),
+			),
+		),
+	) );
+}
+
+add_action( 'init', 'llar_define_risk_config', 1 );
 
 /***************************************************************************************
  * Different ways to get remote address: direct & behind proxy

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -10,7 +10,9 @@ Version: 3.0.2
 Copyright 2008-2012 Johan Eenfeldt, 2016–present Limit Login Attempts Reloaded
 */
 
-if( !defined( 'ABSPATH' ) ) exit;
+if ( !defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /***************************************************************************************
  * Constants
@@ -21,18 +23,12 @@ define( 'LLA_PLUGIN_FILE', __FILE__ );
 define( 'LLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 /**
- * Risk widget config (colors, level rules). Not a global define — avoids pre-init overrides.
+ * Default risk widget config (bounds, colors, level rules).
  *
  * @return array
  */
-function llar_get_risk_config() {
-	static $cached = null;
-
-	if ( null !== $cached ) {
-		return $cached;
-	}
-
-	$cached = array(
+function llar_get_risk_config_defaults() {
+	return array(
 		'bounds' => array(
 			'low_upper'    => 100,
 			'medium_upper' => 300,
@@ -44,19 +40,99 @@ function llar_get_risk_config() {
 			'red'    => '#FF6633',
 		),
 		'levels' => array(
-			'local' => array(
-				array( 'exact' => 0, 'title' => 'zero_title', 'color' => 'green' ),
-				array( 'max_exclusive' => 100, 'count_title' => true, 'desc' => 'desc_low', 'color' => 'yellow' ),
-				array( 'max_exclusive' => 300, 'count_title' => true, 'desc' => 'desc_medium', 'recommendation' => true, 'color' => 'orange' ),
-				array( 'default' => true, 'warning_title' => true, 'recommendation' => true, 'color' => 'red' ),
+			'local'                 => array(
+				array(
+					'exact' => 0,
+					'title' => 'zero_title',
+					'color' => 'green',
+				),
+				array(
+					'max_exclusive' => 100,
+					'count_title'   => true,
+					'desc'          => 'desc_low',
+					'color'         => 'yellow',
+				),
+				array(
+					'max_exclusive'  => 300,
+					'count_title'    => true,
+					'desc'           => 'desc_medium',
+					'recommendation' => true,
+					'color'          => 'orange',
+				),
+				array(
+					'default'        => true,
+					'warning_title'  => true,
+					'recommendation' => true,
+					'color'          => 'red',
+				),
 			),
 			'cloud_exhausted_micro' => array(
-				array( 'exact' => 0, 'title' => 'zero_title', 'color' => 'green' ),
-				array( 'max_exclusive' => 100, 'count_title' => true, 'desc' => 'desc_low', 'color' => 'orange' ),
-				array( 'default' => true, 'premium_recommendation' => true, 'color' => 'red' ),
+				array(
+					'exact' => 0,
+					'title' => 'zero_title',
+					'color' => 'green',
+				),
+				array(
+					'max_exclusive' => 100,
+					'count_title'   => true,
+					'desc'          => 'desc_low',
+					'color'         => 'orange',
+				),
+				array(
+					'default'                => true,
+					'premium_recommendation' => true,
+					'color'                  => 'red',
+				),
 			),
 		),
 	);
+}
+
+/**
+ * Merge filtered config with defaults so colors/levels/bounds always exist.
+ *
+ * @param array $defaults Default config.
+ * @param mixed $cfg      Filtered value.
+ *
+ * @return array
+ */
+function llar_normalize_risk_config( $defaults, $cfg ) {
+	if ( ! is_array( $cfg ) ) {
+		return $defaults;
+	}
+
+	$out = $cfg;
+	foreach ( array( 'bounds', 'colors', 'levels' ) as $key ) {
+		if ( ! isset( $out[ $key ] ) || ! is_array( $out[ $key ] ) ) {
+			$out[ $key ] = $defaults[ $key ];
+		}
+	}
+
+	if ( ! isset( $out['levels']['local'] ) || ! is_array( $out['levels']['local'] ) ) {
+		$out['levels']['local'] = $defaults['levels']['local'];
+	}
+	if ( ! isset( $out['levels']['cloud_exhausted_micro'] ) || ! is_array( $out['levels']['cloud_exhausted_micro'] ) ) {
+		$out['levels']['cloud_exhausted_micro'] = $defaults['levels']['cloud_exhausted_micro'];
+	}
+
+	return $out;
+}
+
+/**
+ * Risk widget config (colors, level rules). Cached per request; overridable via llar_risk_config filter.
+ *
+ * @return array
+ */
+function llar_get_risk_config() {
+	static $cached = null;
+
+	if ( null !== $cached ) {
+		return $cached;
+	}
+
+	$defaults = llar_get_risk_config_defaults();
+	$merged   = apply_filters( 'llar_risk_config', $defaults );
+	$cached   = llar_normalize_risk_config( $defaults, $merged );
 
 	return $cached;
 }
@@ -128,18 +204,22 @@ defined( 'LLA_MFA_API_PATH' ) || define( 'LLA_MFA_API_PATH', '/mfa' );
 defined( 'LLA_MFA_SESSION_TTL' ) || define( 'LLA_MFA_SESSION_TTL', 600 ); /* seconds, 10 minutes */
 defined( 'LLA_MFA_PROVIDER' ) || define( 'LLA_MFA_PROVIDER', 'llar' );
 
-$um_limit_login_failed = false;
-$limit_login_my_error_shown = false; /* have we shown our stuff? */
-$limit_login_just_lockedout = false; /* started this pageload??? */
+$um_limit_login_failed            = false;
+$limit_login_my_error_shown       = false; /* have we shown our stuff? */
+$limit_login_just_lockedout       = false; /* started this pageload??? */
 $limit_login_nonempty_credentials = false; /* user and pwd nonempty */
 
-if( file_exists( LLA_PLUGIN_DIR . 'autoload.php' ) ) {
+if ( file_exists( LLA_PLUGIN_DIR . 'autoload.php' ) ) {
 
-	require_once( LLA_PLUGIN_DIR . 'autoload.php' );
+	require_once LLA_PLUGIN_DIR . 'autoload.php';
 
-	add_action( 'plugins_loaded', function() {
-		(new LLAR\Core\LimitLoginAttempts());
-	}, 9999 );
+	add_action(
+		'plugins_loaded',
+		function () {
+			( new LLAR\Core\LimitLoginAttempts() );
+		},
+		9999
+	);
 
 	/**
 	 * Activation hook: Cleanup old cron events and transients
@@ -203,7 +283,7 @@ if( file_exists( LLA_PLUGIN_DIR . 'autoload.php' ) ) {
 			return array();
 		}
 		$prefix_len = strlen( '_transient_timeout_' );
-		$keys      = array();
+		$keys       = array();
 		foreach ( $names as $name ) {
 			$keys[] = substr( $name, $prefix_len );
 		}
@@ -240,7 +320,7 @@ if( file_exists( LLA_PLUGIN_DIR . 'autoload.php' ) ) {
 			return array();
 		}
 		$prefix_len = strlen( '_transient_timeout_' );
-		$keys      = array();
+		$keys       = array();
 		foreach ( $names as $name ) {
 			$keys[] = substr( $name, $prefix_len );
 		}

--- a/views/admin-dashboard-widgets.php
+++ b/views/admin-dashboard-widgets.php
@@ -26,6 +26,14 @@ if ( $is_active_app_custom ) {
 
 $api_stats = $is_active_app_custom ? LimitLoginAttempts::$cloud_app->stats() : false;
 $setup_code = Config::get( 'app_setup_code' );
+$chart_circle_data = $this->get_failed_attempts_circle_data(
+	$is_active_app_custom,
+	$is_exhausted,
+	$block_sub_group,
+	$setup_code,
+	$upgrade_premium_url,
+	$api_stats
+);
 ?>
 
 <div id="llar-admin-dashboard-widgets">

--- a/views/chart-circle-failed-attempts-today.php
+++ b/views/chart-circle-failed-attempts-today.php
@@ -12,100 +12,16 @@
  *
  */
 
-use LLAR\Core\Config;
 use LLAR\Core\Helpers;
 
-$retries_chart_title = '';
-$retries_chart_desc  = '';
-$retries_chart_color = '';
-$retries_count       = 0;
-
-if ( ! $is_active_app_custom ) {
-
-	$retries_stats = Config::get( 'retries_stats' );
-
-	if ( $retries_stats ) {
-		foreach ( $retries_stats as $key => $count ) {
-			if ( is_numeric( $key ) && $key > strtotime( '-24 hours' ) ) {
-				$retries_count += $count;
-			}
-            elseif( !is_numeric( $key ) && date_i18n( 'Y-m-d' ) === $key ) {
-				$retries_count += $count;
-			}
-		}
-	}
-
-	if ( $retries_count === 0 ) {
-
-		$retries_chart_title = __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
-		$retries_chart_color = '#97F6C8';
-	}
-	else if ( $retries_count < 100 ) {
-
-		$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
-		$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
-		$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
-		$retries_chart_color = '#FFE066';
-	} else if ( $retries_count < 300 ) {
-
-		$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
-		$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
-		$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
-		$retries_chart_color = '#FFCC66';
-	} else if ( $retries_count < 500 ) {
-
-		$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
-		$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
-		$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
-		$retries_chart_color = '#FF4D4F';
-	} else {
-
-		$retries_chart_title = __( 'Warning: Your site has experienced over 500 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
-
-		if ( ! empty( $setup_code ) ) {
-			$retries_chart_desc = sprintf(
-				__( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
-				$upgrade_premium_url );
-		} else {
-			$retries_chart_desc = sprintf(
-				__( 'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
-				'button_micro_cloud' );
-        }
-
-		$retries_chart_color = '#FF6633';
-	}
-
-} else {
-
-	if ( $api_stats && ! empty( $api_stats['attempts']['count'] ) ) {
-		$retries_count = (int) end( $api_stats['attempts']['count'] );
-	}
-
-	if ( $is_exhausted && $block_sub_group === 'Micro Cloud' ) {
-
-		if ( $retries_count === 0 ) {
-			$retries_chart_title = __( 'Hooray! Zero failed login attempts (past 24 hrs)', 'limit-login-attempts-reloaded' );
-			$retries_chart_color = '#97F6C8';
-
-        } elseif ( $retries_count < 100 ) {
-			$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
-			$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
-			$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
-			$retries_chart_color = '#FFCC66';
-
-        } else {
-			$upgrade_premium_url = ! empty ( $upgrade_premium_url ) ? $upgrade_premium_url : '';
-			$retries_chart_desc = sprintf(
-				__( 'Based on your level of brute force activity, we recommend <a href="%s" class="llar_orange" target="_blank">upgrading to premium</a> to access features to reduce failed logins and improve site performance.', 'limit-login-attempts-reloaded' ),
-				$upgrade_premium_url );
-			$retries_chart_color = '#FF6633';
-        }
-
-    } else {
-		$retries_chart_title = __( 'Failed Login Attempts Today', 'limit-login-attempts-reloaded' );
-		$retries_chart_color = '#97F6C8';
-    }
+if ( empty( $chart_circle_data ) || ! is_array( $chart_circle_data ) ) {
+	return;
 }
+
+$retries_chart_title = isset( $chart_circle_data['retries_chart_title'] ) ? $chart_circle_data['retries_chart_title'] : '';
+$retries_chart_desc  = isset( $chart_circle_data['retries_chart_desc'] ) ? $chart_circle_data['retries_chart_desc'] : '';
+$retries_chart_color = isset( $chart_circle_data['retries_chart_color'] ) ? $chart_circle_data['retries_chart_color'] : '#97F6C8';
+$retries_count       = isset( $chart_circle_data['retries_count'] ) ? (int) $chart_circle_data['retries_count'] : 0;
 ?>
 
 <div class="section-title__new">

--- a/views/chart-circle-failed-attempts-today.php
+++ b/views/chart-circle-failed-attempts-today.php
@@ -45,10 +45,22 @@ if ( ! $is_active_app_custom ) {
 		$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
 		$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
 		$retries_chart_desc = __( 'Your site is currently at a low risk for brute force activity', 'limit-login-attempts-reloaded' );
+		$retries_chart_color = '#FFE066';
+	} else if ( $retries_count < 300 ) {
+
+		$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
+		$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
+		$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
 		$retries_chart_color = '#FFCC66';
+	} else if ( $retries_count < 500 ) {
+
+		$retries_chart_title = sprintf( _n( '%d failed login attempt ', '%d failed login attempts ', $retries_count, 'limit-login-attempts-reloaded' ), $retries_count );
+		$retries_chart_title .= __( '(past 24 hrs)', 'limit-login-attempts-reloaded' );
+		$retries_chart_desc = __( 'Your site is currently at a medium risk for brute force activity', 'limit-login-attempts-reloaded' );
+		$retries_chart_color = '#FF4D4F';
 	} else {
 
-		$retries_chart_title = __( 'Warning: Your site has experienced over 100 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
+		$retries_chart_title = __( 'Warning: Your site has experienced over 500 failed login attempts in the past 24 hours', 'limit-login-attempts-reloaded' );
 
 		if ( ! empty( $setup_code ) ) {
 			$retries_chart_desc = sprintf(

--- a/views/chart-circle-failed-attempts-today.php
+++ b/views/chart-circle-failed-attempts-today.php
@@ -106,5 +106,5 @@ $retries_count       = isset( $chart_circle_data['retries_count'] ) ? (int) $cha
     } )();
 </script>
 <div class="title<?php echo $active_app !== 'local' ? ' title-big' : ''?>"><?php echo esc_html( $retries_chart_title ); ?></div>
-<div class="desc"><?php echo $retries_chart_desc; ?></div>
+<div class="desc"><?php echo wp_kses_post( $retries_chart_desc ); ?></div>
 

--- a/views/tab-dashboard.php
+++ b/views/tab-dashboard.php
@@ -18,6 +18,14 @@ if ( ! defined( 'ABSPATH' ) ) exit();
 $api_stats = $is_active_app_custom ? LimitLoginAttempts::$cloud_app->stats() : false;
 
 $setup_code = Config::get( 'app_setup_code' );
+$chart_circle_data = $this->get_failed_attempts_circle_data(
+	$is_active_app_custom,
+	$is_exhausted,
+	$block_sub_group,
+	$setup_code,
+	$upgrade_premium_url,
+	$api_stats
+);
 
 $wp_locale = str_replace( '_', '-', get_locale() );
 $is_tab_dashboard = true;


### PR DESCRIPTION
## Summary
- update local risk thresholds/colors for failed login attempts: `0` green, `1-99` yellow, `100-299` orange, `300+` red
- move risk chart mapping to a single configurable structure (`LLA_RISK_CONFIG`) initialized on `init`, including ranges, colors, and labels
- simplify risk display rendering by resolving a matched level and applying one iterative rule flow instead of duplicated branch logic

## Risk donut: colors and copy (default thresholds)

Thresholds and hex values come from `llar_get_risk_config_defaults()` (override via `llar_risk_config` filter).

### Local mode (`! is_active_app_custom`)

Uses **failed login attempts in the past 24 hours** (`get_local_retries_count_for_last_day()`).

| Retries (24h) | Donut color | Hex | Title (summary) | Description under title |
|---------------|-------------|-----|-----------------|-------------------------|
| **0** | Green | `#97F6C8` | “Hooray! Zero failed login attempts (past 24 hrs)” | *(empty)* |
| **1–99** | Yellow | `#FFE066` | “*N* failed login attempt(s) … (past 24 hrs)” | Low risk sentence (ends with period) |
| **100–299** | Orange | `#FFCC66` | Same count-style title | Medium risk sentence + **recommendation** block (“Based on your level…”, premium vs Micro Cloud by `setup_code`) |
| **300+** | Red | `#FF6633` | “Your site has experienced *T*+ failed login attempts in the past 24 hours.” (*T* = `bounds.medium_upper`, default **300**) | Recommendation block only (no separate medium line) |

### Custom Cloud (`is_active_app_custom`)

Uses **last numeric value** from API `attempts.count` (array of daily buckets).

| Retries (API) | Donut color | Hex | Title | Description |
|---------------|-------------|-----|-------|-------------|
| **any** | Green | `#97F6C8` | “Failed Login Attempts Today” | *(empty)* — no local risk bands |