### PR TITLE
fix(security): protect close premium message AJAX action

### DIFF
--- a/core/Ajax.php
+++ b/core/Ajax.php
@@ -1020,6 +1020,8 @@ class Ajax
 
     public function close_premium_message() {
 
+	    $this->check_user_capabilities();
+
 	    check_ajax_referer( 'llar-close-premium-message', 'sec' );
 
 	    Config::update( 'notifications_message_shown', strtotime( '+1 day' ) );


### PR DESCRIPTION
## Summary
- add capability validation to `close_premium_message` AJAX handler in `core/Ajax.php`
- keep existing nonce verification and behavior unchanged for authorized users
- prevent low-privilege authenticated users from mutating plugin-wide `notifications_message_shown`