### PR TITLE
fix(mfa): skip MFA flow when no roles selected

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -73,7 +73,7 @@ class Config {
 		'mfa_enabled'                   => 0,
 		'mfa_provider'                  => 'llar',
 		'mfa_provider_config'           => array(),
-		'mfa_roles'                     => array(),
+		'mfa_roles'                     => array( 'administrator' ),
 	);
 
 	private static $disable_autoload_options = array(

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -1918,11 +1918,11 @@ class LimitLoginAttempts
 				$user = get_user_by( 'email', $username );
 			}
 		}
-
-		$mfa_roles        = Config::get( 'mfa_roles', array() );
-		$mfa_roles        = is_array( $mfa_roles ) ? $mfa_roles : array();
-		$user_excluded    = $user && ! empty( $mfa_roles ) && ! array_intersect( (array) $user->roles, $mfa_roles );
-		$should_trigger_mfa = $mfa_enabled && ! $user_excluded;
+		$mfa_roles         = Config::get( 'mfa_roles', array() );
+		$mfa_roles         = is_array( $mfa_roles ) ? $mfa_roles : array();
+		$has_mfa_groups    = ! empty( $mfa_roles );
+		$user_excluded     = $user && $has_mfa_groups && ! array_intersect( (array) $user->roles, $mfa_roles );
+		$should_trigger_mfa = $mfa_enabled && $has_mfa_groups && ! $user_excluded;
 
 		if ( ! $should_trigger_mfa ) {
 			return;


### PR DESCRIPTION
## Summary
- prevent MFA flow redirect when MFA is enabled but no roles are selected
- require at least one configured MFA role before evaluating user role inclusion
- keep existing behavior unchanged when roles are configured