### PR TITLE
fix(mfa): pluggable rescue payload storage with provider fallback

### DIFF
--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -212,10 +212,11 @@ class LimitLoginAttempts
 		$this->cloud_app_init();
 
 		// Initialize MFA (dependency injection: MfaBackupCodes, MfaEndpoint, MfaSettings)
-		$mfa_backup_codes = new \LLAR\Core\Mfa\MfaBackupCodes();
-		$mfa_endpoint     = new \LLAR\Core\Mfa\MfaEndpoint( $mfa_backup_codes );
+		$payload_storage = \LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageSelector::get_storage();
+		$mfa_backup_codes = new \LLAR\Core\Mfa\MfaBackupCodes( $payload_storage );
+		$mfa_endpoint     = new \LLAR\Core\Mfa\MfaEndpoint( $mfa_backup_codes, $payload_storage );
 		$mfa_settings    = new \LLAR\Core\Mfa\MfaSettings();
-		$this->mfa_controller = new \LLAR\Core\Mfa\MfaManager( $mfa_backup_codes, $mfa_endpoint, $mfa_settings );
+		$this->mfa_controller = new \LLAR\Core\Mfa\MfaManager( $mfa_backup_codes, $mfa_endpoint, $mfa_settings, $payload_storage );
 		$this->mfa_controller->register();
 
 		( new Shortcodes() )->register();
@@ -3171,53 +3172,12 @@ class LimitLoginAttempts
 			return false;
 		}
 
-		$seconds_left = $this->get_mfa_rescue_links_seconds_left();
+		$seconds_left = $this->mfa_controller->get_rescue_links_seconds_left();
 		if ( null === $seconds_left ) {
 			return true;
 		}
 
 		return $seconds_left <= MfaConstants::RESCUE_NOTICE_THRESHOLD;
-	}
-
-	/**
-	 * Return seconds left until the latest rescue-link transient expiration.
-	 * Result is cached (see MfaConstants::RESCUE_MAX_EXPIRY_CACHE_*) to limit repeated LIKE queries on wp_options.
-	 *
-	 * @return int|null Null when rescue transients are absent.
-	 */
-	private function get_mfa_rescue_links_seconds_left() {
-		$cache_key = MfaConstants::RESCUE_MAX_EXPIRY_CACHE_KEY;
-		$cached    = get_transient( $cache_key );
-
-		if ( false !== $cached && is_numeric( $cached ) ) {
-			$max_timeout = (int) $cached;
-			if ( -1 === $max_timeout ) {
-				return null;
-			}
-			if ( 0 < $max_timeout ) {
-				return $max_timeout - time();
-			}
-		}
-
-		global $wpdb;
-
-		$timeout_like = $wpdb->esc_like( '_transient_timeout_' . MfaConstants::TRANSIENT_RESCUE_PREFIX ) . '%';
-
-		$max_timeout = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT MAX(CAST(option_value AS UNSIGNED)) FROM ' . $wpdb->options . ' WHERE option_name LIKE %s',
-				$timeout_like
-			)
-		);
-
-		$cache_value = 0 === $max_timeout ? -1 : $max_timeout;
-		set_transient( $cache_key, $cache_value, MfaConstants::RESCUE_MAX_EXPIRY_CACHE_TTL );
-
-		if ( 0 === $max_timeout ) {
-			return null;
-		}
-
-		return $max_timeout - time();
 	}
 
 	/**

--- a/core/mfa/MfaBackupCodes.php
+++ b/core/mfa/MfaBackupCodes.php
@@ -25,9 +25,12 @@ class MfaBackupCodes implements MfaBackupCodesInterface {
 	private $payload_storage;
 
 	/**
-	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage.
+	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage (no type hint on param: PHP 8.4 implicit-null deprecation; validated below).
 	 */
-	public function __construct( RescuePayloadStorageInterface $payload_storage = null ) {
+	public function __construct( $payload_storage = null ) {
+		if ( null !== $payload_storage && ! $payload_storage instanceof RescuePayloadStorageInterface ) {
+			throw new \InvalidArgumentException( 'Expected RescuePayloadStorageInterface or null.' );
+		}
 		$this->payload_storage = $payload_storage ? $payload_storage : RescuePayloadStorageSelector::get_storage();
 	}
 

--- a/core/mfa/MfaBackupCodes.php
+++ b/core/mfa/MfaBackupCodes.php
@@ -3,6 +3,8 @@
 namespace LLAR\Core\Mfa;
 
 use LLAR\Core\MfaConstants;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageInterface;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageSelector;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -16,6 +18,18 @@ class MfaBackupCodes implements MfaBackupCodesInterface {
 	const CIPHER_METHOD = 'AES-256-CBC';
 	const PAYLOAD_VERSION = 'v2:';
 	const BASE62_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+	/**
+	 * @var RescuePayloadStorageInterface
+	 */
+	private $payload_storage;
+
+	/**
+	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage.
+	 */
+	public function __construct( RescuePayloadStorageInterface $payload_storage = null ) {
+		$this->payload_storage = $payload_storage ? $payload_storage : RescuePayloadStorageSelector::get_storage();
+	}
 
 	/**
 	 * Encrypt plain code for storage. OpenSSL only; returns false if unavailable.
@@ -233,8 +247,7 @@ class MfaBackupCodes implements MfaBackupCodesInterface {
 		}
 		// Store encrypted payload in a dedicated transient per hash_id.
 		// This allows atomic, single-use consumption on the endpoint side.
-		$transient_key = MfaConstants::TRANSIENT_RESCUE_PREFIX . $hash_id;
-		set_transient( $transient_key, $encrypted, MfaConstants::RESCUE_LINK_TTL );
+		$this->payload_storage->save( $hash_id, $encrypted, MfaConstants::RESCUE_LINK_TTL );
 		return add_query_arg( 'llar_rescue', $hash_id, home_url() );
 	}
 

--- a/core/mfa/MfaEndpoint.php
+++ b/core/mfa/MfaEndpoint.php
@@ -43,10 +43,13 @@ class MfaEndpoint implements MfaEndpointInterface {
 	/**
 	 * Constructor.
 	 *
-	 * @param MfaBackupCodesInterface                 $backup_codes    Backup codes service (decrypt, verify).
-	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage.
+	 * @param MfaBackupCodesInterface            $backup_codes     Backup codes service (decrypt, verify).
+	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage (no type hint on param: PHP 8.4 implicit-null deprecation; validated below).
 	 */
-	public function __construct( MfaBackupCodesInterface $backup_codes, RescuePayloadStorageInterface $payload_storage = null ) {
+	public function __construct( MfaBackupCodesInterface $backup_codes, $payload_storage = null ) {
+		if ( null !== $payload_storage && ! $payload_storage instanceof RescuePayloadStorageInterface ) {
+			throw new \InvalidArgumentException( 'Expected RescuePayloadStorageInterface or null.' );
+		}
 		$this->backup_codes    = $backup_codes;
 		$this->payload_storage = $payload_storage ? $payload_storage : RescuePayloadStorageSelector::get_storage();
 		switch ( true ) {

--- a/core/mfa/MfaEndpoint.php
+++ b/core/mfa/MfaEndpoint.php
@@ -3,8 +3,11 @@
 namespace LLAR\Core\Mfa;
 
 use LLAR\Core\Config;
+use LLAR\Core\MfaConstants;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadOptionsStorage;
 use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageInterface;
 use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageSelector;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadTransientStorage;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -33,6 +36,11 @@ class MfaEndpoint implements MfaEndpointInterface {
 	private $payload_storage;
 
 	/**
+	 * @var RescuePayloadStorageInterface[]
+	 */
+	private $fallback_storages = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param MfaBackupCodesInterface                 $backup_codes    Backup codes service (decrypt, verify).
@@ -41,6 +49,14 @@ class MfaEndpoint implements MfaEndpointInterface {
 	public function __construct( MfaBackupCodesInterface $backup_codes, RescuePayloadStorageInterface $payload_storage = null ) {
 		$this->backup_codes    = $backup_codes;
 		$this->payload_storage = $payload_storage ? $payload_storage : RescuePayloadStorageSelector::get_storage();
+		switch ( true ) {
+			case $this->payload_storage instanceof RescuePayloadTransientStorage:
+				$this->fallback_storages[] = new RescuePayloadOptionsStorage();
+				break;
+			case $this->payload_storage instanceof RescuePayloadOptionsStorage:
+				$this->fallback_storages[] = new RescuePayloadTransientStorage();
+				break;
+		}
 	}
 
 	/**
@@ -75,13 +91,13 @@ class MfaEndpoint implements MfaEndpointInterface {
 
 		$plain_code = $this->backup_codes->decrypt_code( $encrypted_data );
 		if ( false === $plain_code ) {
-			$this->payload_storage->delete( $hash_id );
+			$this->delete_rescue_payload( $hash_id );
 			wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 		}
 
 		$codes = Config::get( 'mfa_rescue_codes', array() );
 		if ( ! is_array( $codes ) || empty( $codes ) ) {
-			$this->payload_storage->delete( $hash_id );
+			$this->delete_rescue_payload( $hash_id );
 			wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 		}
 
@@ -99,7 +115,7 @@ class MfaEndpoint implements MfaEndpointInterface {
 		}
 
 		if ( $code_verified && null !== $verified_index ) {
-			$deleted = $this->payload_storage->delete( $hash_id );
+			$deleted = $this->delete_rescue_payload( $hash_id );
 			if ( ! $deleted ) {
 				wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 			}
@@ -113,7 +129,7 @@ class MfaEndpoint implements MfaEndpointInterface {
 			exit;
 		}
 
-		$this->payload_storage->delete( $hash_id );
+		$this->delete_rescue_payload( $hash_id );
 		wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 	}
 
@@ -126,6 +142,14 @@ class MfaEndpoint implements MfaEndpointInterface {
 	 */
 	private function read_rescue_encrypted_payload( $hash_id ) {
 		$encrypted_data = $this->payload_storage->read( $hash_id );
+		if ( false === $encrypted_data ) {
+			foreach ( $this->fallback_storages as $fallback_storage ) {
+				$encrypted_data = $fallback_storage->read( $hash_id );
+				if ( false !== $encrypted_data ) {
+					break;
+				}
+			}
+		}
 		if ( false === $encrypted_data ) {
 			return false;
 		}
@@ -146,6 +170,20 @@ class MfaEndpoint implements MfaEndpointInterface {
 			return false;
 		}
 		return $encrypted_data;
+	}
+
+	/**
+	 * Delete payload from primary provider and fallbacks.
+	 *
+	 * @param string $hash_id Rescue hash id.
+	 * @return bool
+	 */
+	private function delete_rescue_payload( $hash_id ) {
+		$deleted = (bool) $this->payload_storage->delete( $hash_id );
+		foreach ( $this->fallback_storages as $fallback_storage ) {
+			$deleted = (bool) ( $fallback_storage->delete( $hash_id ) || $deleted );
+		}
+		return $deleted;
 	}
 
 	/**

--- a/core/mfa/MfaEndpoint.php
+++ b/core/mfa/MfaEndpoint.php
@@ -3,7 +3,8 @@
 namespace LLAR\Core\Mfa;
 
 use LLAR\Core\Config;
-use LLAR\Core\MfaConstants;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageInterface;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageSelector;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -26,14 +27,20 @@ class MfaEndpoint implements MfaEndpointInterface {
 	 * @var MfaBackupCodesInterface
 	 */
 	private $backup_codes;
+	/**
+	 * @var RescuePayloadStorageInterface
+	 */
+	private $payload_storage;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param MfaBackupCodesInterface $backup_codes Backup codes service (decrypt, verify).
+	 * @param MfaBackupCodesInterface                 $backup_codes    Backup codes service (decrypt, verify).
+	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage.
 	 */
-	public function __construct( MfaBackupCodesInterface $backup_codes ) {
-		$this->backup_codes = $backup_codes;
+	public function __construct( MfaBackupCodesInterface $backup_codes, RescuePayloadStorageInterface $payload_storage = null ) {
+		$this->backup_codes    = $backup_codes;
+		$this->payload_storage = $payload_storage ? $payload_storage : RescuePayloadStorageSelector::get_storage();
 	}
 
 	/**
@@ -68,13 +75,13 @@ class MfaEndpoint implements MfaEndpointInterface {
 
 		$plain_code = $this->backup_codes->decrypt_code( $encrypted_data );
 		if ( false === $plain_code ) {
-			$this->remove_rescue_payload_from_options( $hash_id );
+			$this->payload_storage->delete( $hash_id );
 			wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 		}
 
 		$codes = Config::get( 'mfa_rescue_codes', array() );
 		if ( ! is_array( $codes ) || empty( $codes ) ) {
-			$this->remove_rescue_payload_from_options( $hash_id );
+			$this->payload_storage->delete( $hash_id );
 			wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 		}
 
@@ -92,8 +99,8 @@ class MfaEndpoint implements MfaEndpointInterface {
 		}
 
 		if ( $code_verified && null !== $verified_index ) {
-			$deleted = $this->remove_rescue_payload_from_options( $hash_id );
-			if ( 1 !== (int) $deleted ) {
+			$deleted = $this->payload_storage->delete( $hash_id );
+			if ( ! $deleted ) {
 				wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 			}
 			$rescue_code = RescueCode::from_array( $codes[ $verified_index ] );
@@ -106,7 +113,7 @@ class MfaEndpoint implements MfaEndpointInterface {
 			exit;
 		}
 
-		$this->remove_rescue_payload_from_options( $hash_id );
+		$this->payload_storage->delete( $hash_id );
 		wp_die( self::MSG_ERROR, 'LLAR MFA Rescue', array( 'response' => 403 ) );
 	}
 
@@ -118,21 +125,7 @@ class MfaEndpoint implements MfaEndpointInterface {
 	 * @return string|false Encrypted payload or false.
 	 */
 	private function read_rescue_encrypted_payload( $hash_id ) {
-		$transient_key  = MfaConstants::TRANSIENT_RESCUE_PREFIX . $hash_id;
-		$encrypted_data = get_transient( $transient_key );
-		if ( false === $encrypted_data ) {
-			global $wpdb;
-			$option_name = '_transient_' . $transient_key;
-			$raw         = $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT option_value FROM ' . $wpdb->options . ' WHERE option_name = %s LIMIT 1',
-					$option_name
-				)
-			);
-			if ( null !== $raw && '' !== $raw ) {
-				$encrypted_data = maybe_unserialize( $raw );
-			}
-		}
+		$encrypted_data = $this->payload_storage->read( $hash_id );
 		if ( false === $encrypted_data ) {
 			return false;
 		}
@@ -153,35 +146,6 @@ class MfaEndpoint implements MfaEndpointInterface {
 			return false;
 		}
 		return $encrypted_data;
-	}
-
-	/**
-	 * Remove the one-time payload row from the database (and timeout row). Returns rows deleted (0 or 1 for value row).
-	 *
-	 * @param string $hash_id Validated hash_id.
-	 * @return int Deleted rows for _transient_* value row.
-	 */
-	private function remove_rescue_payload_from_options( $hash_id ) {
-		$transient_key = MfaConstants::TRANSIENT_RESCUE_PREFIX . $hash_id;
-		global $wpdb;
-		$option_name = '_transient_' . $transient_key;
-		$deleted     = $wpdb->query(
-			$wpdb->prepare(
-				'DELETE FROM ' . $wpdb->options . ' WHERE option_name = %s',
-				$option_name
-			)
-		);
-		if ( 1 === (int) $deleted ) {
-			$timeout_name = '_transient_timeout_' . $transient_key;
-			$wpdb->query(
-				$wpdb->prepare(
-					'DELETE FROM ' . $wpdb->options . ' WHERE option_name = %s',
-					$timeout_name
-				)
-			);
-			delete_transient( MfaConstants::RESCUE_MAX_EXPIRY_CACHE_KEY );
-		}
-		return (int) $deleted;
 	}
 
 	/**

--- a/core/mfa/MfaManager.php
+++ b/core/mfa/MfaManager.php
@@ -113,9 +113,12 @@ class MfaManager {
 	 * @param MfaBackupCodesInterface              $backup_codes    Backup/rescue codes service.
 	 * @param MfaEndpointInterface                 $endpoint        Rescue endpoint handler.
 	 * @param MfaSettingsInterface                 $settings        MFA settings service.
-	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage.
+	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage (no type hint on param: PHP 8.4 implicit-null deprecation; validated below).
 	 */
-	public function __construct( MfaBackupCodesInterface $backup_codes, MfaEndpointInterface $endpoint, MfaSettingsInterface $settings, RescuePayloadStorageInterface $payload_storage = null ) {
+	public function __construct( MfaBackupCodesInterface $backup_codes, MfaEndpointInterface $endpoint, MfaSettingsInterface $settings, $payload_storage = null ) {
+		if ( null !== $payload_storage && ! $payload_storage instanceof RescuePayloadStorageInterface ) {
+			throw new \InvalidArgumentException( 'Expected RescuePayloadStorageInterface or null.' );
+		}
 		$this->backup_codes    = $backup_codes;
 		$this->endpoint        = $endpoint;
 		$this->settings        = $settings;

--- a/core/mfa/MfaManager.php
+++ b/core/mfa/MfaManager.php
@@ -4,6 +4,8 @@ namespace LLAR\Core\Mfa;
 
 use LLAR\Core\Config;
 use LLAR\Core\MfaConstants;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageInterface;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageSelector;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,6 +29,8 @@ class MfaManager {
 	private $endpoint;
 	/** @var MfaSettingsInterface */
 	private $settings;
+	/** @var RescuePayloadStorageInterface */
+	private $payload_storage;
 
 	/**
 	 * Build per-user transient key for pending rescue hashes.
@@ -102,37 +106,31 @@ class MfaManager {
 	}
 
 	/**
-	 * Whether the _transient_* row for this rescue payload exists in wp_options.
+	 * Constructor. Dependencies are injected for testability and single responsibility.
 	 *
-	 * @param string $transient_key Full transient name (prefix + hash), no _transient_ part.
-	 * @return bool
+	 * @param MfaBackupCodesInterface              $backup_codes    Backup/rescue codes service.
+	 * @param MfaEndpointInterface                 $endpoint        Rescue endpoint handler.
+	 * @param MfaSettingsInterface                 $settings        MFA settings service.
+	 * @param RescuePayloadStorageInterface|null $payload_storage Rescue payload storage.
 	 */
-	private function rescue_transient_row_exists( $transient_key ) {
-		global $wpdb;
-		if ( '' === $transient_key || ! is_string( $transient_key ) ) {
-			return false;
-		}
-		$option_name = '_transient_' . $transient_key;
-		$one         = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT 1 FROM ' . $wpdb->options . ' WHERE option_name = %s LIMIT 1',
-				$option_name
-			)
-		);
-		return null !== $one;
+	public function __construct( MfaBackupCodesInterface $backup_codes, MfaEndpointInterface $endpoint, MfaSettingsInterface $settings, RescuePayloadStorageInterface $payload_storage = null ) {
+		$this->backup_codes    = $backup_codes;
+		$this->endpoint        = $endpoint;
+		$this->settings        = $settings;
+		$this->payload_storage = $payload_storage ? $payload_storage : RescuePayloadStorageSelector::get_storage();
 	}
 
 	/**
-	 * Constructor. Dependencies are injected for testability and single responsibility.
+	 * Return seconds left until latest rescue payload expiry.
 	 *
-	 * @param MfaBackupCodesInterface $backup_codes Backup/rescue codes service.
-	 * @param MfaEndpointInterface    $endpoint    Rescue endpoint handler.
-	 * @param MfaSettingsInterface   $settings    MFA settings service.
+	 * @return int|null
 	 */
-	public function __construct( MfaBackupCodesInterface $backup_codes, MfaEndpointInterface $endpoint, MfaSettingsInterface $settings ) {
-		$this->backup_codes = $backup_codes;
-		$this->endpoint     = $endpoint;
-		$this->settings     = $settings;
+	public function get_rescue_links_seconds_left() {
+		$max_expiry = $this->payload_storage->get_max_expiry();
+		if ( null === $max_expiry ) {
+			return null;
+		}
+		return (int) $max_expiry - time();
 	}
 
 	/**
@@ -424,12 +422,11 @@ class MfaManager {
 		// same request (some object-cache setups don't expose just-set transients to the same process,
 		// and the first slot occasionally misses — regenerate so every URL has a live payload).
 		foreach ( $rescue_urls as $i => $u ) {
-			$h  = $this->get_rescue_hash_from_rescue_url( $u );
-			$tk = ( '' === $h ) ? '' : ( MfaConstants::TRANSIENT_RESCUE_PREFIX . $h );
-			if ( '' === $tk ) {
+			$h = $this->get_rescue_hash_from_rescue_url( $u );
+			if ( '' === $h ) {
 				continue;
 			}
-			if ( false !== get_transient( $tk ) || $this->rescue_transient_row_exists( $tk ) ) {
+			if ( $this->payload_storage->exists( $h ) ) {
 				continue;
 			}
 			if ( ! isset( $plain_codes[ $i ] ) || ! is_string( $plain_codes[ $i ] ) ) {

--- a/core/mfa/MfaManager.php
+++ b/core/mfa/MfaManager.php
@@ -4,8 +4,10 @@ namespace LLAR\Core\Mfa;
 
 use LLAR\Core\Config;
 use LLAR\Core\MfaConstants;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadOptionsStorage;
 use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageInterface;
 use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadStorageSelector;
+use LLAR\Core\Mfa\RescuePayloadStorage\RescuePayloadTransientStorage;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -127,6 +129,24 @@ class MfaManager {
 	 */
 	public function get_rescue_links_seconds_left() {
 		$max_expiry = $this->payload_storage->get_max_expiry();
+		if ( null === $max_expiry ) {
+			// Notice must work even when links were generated with another provider
+			// during a different request profile (e.g. AJAX generation path).
+			switch ( true ) {
+				case $this->payload_storage instanceof RescuePayloadTransientStorage:
+					$fallback_expiry = ( new RescuePayloadOptionsStorage() )->get_max_expiry();
+					if ( null !== $fallback_expiry ) {
+						$max_expiry = (int) $fallback_expiry;
+					}
+					break;
+				case $this->payload_storage instanceof RescuePayloadOptionsStorage:
+					$fallback_expiry = ( new RescuePayloadTransientStorage() )->get_max_expiry();
+					if ( null !== $fallback_expiry ) {
+						$max_expiry = (int) $fallback_expiry;
+					}
+					break;
+			}
+		}
 		if ( null === $max_expiry ) {
 			return null;
 		}

--- a/core/mfa/rescuepayloadstorage/RescuePayloadOptionsStorage.php
+++ b/core/mfa/rescuepayloadstorage/RescuePayloadOptionsStorage.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace LLAR\Core\Mfa\RescuePayloadStorage;
+
+use LLAR\Core\MfaConstants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Rescue payload storage backed by wp_options (autoload=no).
+ */
+class RescuePayloadOptionsStorage implements RescuePayloadStorageInterface {
+	const VALUE_PREFIX  = 'llar_mfa_rescue_payload_';
+	const EXPIRY_PREFIX = 'llar_mfa_rescue_expiry_';
+
+	/**
+	 * @param string $hash_id Rescue hash token.
+	 * @return string
+	 */
+	private function get_value_key( $hash_id ) {
+		return self::VALUE_PREFIX . $hash_id;
+	}
+
+	/**
+	 * @param string $hash_id Rescue hash token.
+	 * @return string
+	 */
+	private function get_expiry_key( $hash_id ) {
+		return self::EXPIRY_PREFIX . $hash_id;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save( $hash_id, $encrypted, $ttl ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id || '' === (string) $encrypted ) {
+			return false;
+		}
+		$expiry = time() + max( 1, (int) $ttl );
+		$ok1    = update_option( $this->get_value_key( $hash_id ), (string) $encrypted, false );
+		$ok2    = update_option( $this->get_expiry_key( $hash_id ), (int) $expiry, false );
+		delete_transient( MfaConstants::RESCUE_MAX_EXPIRY_CACHE_KEY );
+		return (bool) ( $ok1 || $ok2 );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function read( $hash_id ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id ) {
+			return false;
+		}
+		$expiry = (int) get_option( $this->get_expiry_key( $hash_id ), 0 );
+		if ( 0 >= $expiry || $expiry < time() ) {
+			$this->delete( $hash_id );
+			return false;
+		}
+		$value = get_option( $this->get_value_key( $hash_id ), false );
+		return ( false === $value || '' === $value ) ? false : $value;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function delete( $hash_id ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id ) {
+			return false;
+		}
+		$exists  = false !== get_option( $this->get_value_key( $hash_id ), false );
+		$deleted = delete_option( $this->get_value_key( $hash_id ) );
+		delete_option( $this->get_expiry_key( $hash_id ) );
+		delete_transient( MfaConstants::RESCUE_MAX_EXPIRY_CACHE_KEY );
+		return (bool) ( $deleted || $exists );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function exists( $hash_id ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id ) {
+			return false;
+		}
+		$value = get_option( $this->get_value_key( $hash_id ), false );
+		if ( false === $value || '' === $value ) {
+			return false;
+		}
+		$expiry = (int) get_option( $this->get_expiry_key( $hash_id ), 0 );
+		if ( 0 >= $expiry || $expiry < time() ) {
+			$this->delete( $hash_id );
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_max_expiry() {
+		global $wpdb;
+		$expiry_like = $wpdb->esc_like( self::EXPIRY_PREFIX ) . '%';
+		$max_expiry  = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT MAX(CAST(option_value AS UNSIGNED)) FROM ' . $wpdb->options . ' WHERE option_name LIKE %s',
+				$expiry_like
+			)
+		);
+		if ( 0 === $max_expiry ) {
+			return null;
+		}
+		return $max_expiry;
+	}
+}

--- a/core/mfa/rescuepayloadstorage/RescuePayloadStorageInterface.php
+++ b/core/mfa/rescuepayloadstorage/RescuePayloadStorageInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace LLAR\Core\Mfa\RescuePayloadStorage;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Storage contract for MFA rescue encrypted payloads.
+ */
+interface RescuePayloadStorageInterface {
+	/**
+	 * Save encrypted payload for hash id.
+	 *
+	 * @param string $hash_id   Rescue hash token.
+	 * @param string $encrypted Encrypted payload.
+	 * @param int    $ttl       TTL in seconds.
+	 * @return bool
+	 */
+	public function save( $hash_id, $encrypted, $ttl );
+
+	/**
+	 * Read encrypted payload by hash id.
+	 *
+	 * @param string $hash_id Rescue hash token.
+	 * @return string|false
+	 */
+	public function read( $hash_id );
+
+	/**
+	 * Delete payload by hash id.
+	 *
+	 * @param string $hash_id Rescue hash token.
+	 * @return bool True when payload existed and delete succeeded.
+	 */
+	public function delete( $hash_id );
+
+	/**
+	 * Check payload existence by hash id.
+	 *
+	 * @param string $hash_id Rescue hash token.
+	 * @return bool
+	 */
+	public function exists( $hash_id );
+
+	/**
+	 * Get max payload expiry as unix timestamp.
+	 *
+	 * @return int|null Null when no payloads exist.
+	 */
+	public function get_max_expiry();
+}

--- a/core/mfa/rescuepayloadstorage/RescuePayloadStorageSelector.php
+++ b/core/mfa/rescuepayloadstorage/RescuePayloadStorageSelector.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace LLAR\Core\Mfa\RescuePayloadStorage;
+
+use LLAR\Core\MfaConstants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Selects the best rescue payload storage for current environment.
+ */
+class RescuePayloadStorageSelector {
+	/**
+	 * @var RescuePayloadStorageInterface|null
+	 */
+	private static $selected = null;
+
+	/**
+	 * Select storage provider.
+	 *
+	 * @return RescuePayloadStorageInterface
+	 */
+	public static function get_storage() {
+		if ( null !== self::$selected ) {
+			return self::$selected;
+		}
+
+		$transient_storage = new RescuePayloadTransientStorage();
+		$options_storage   = new RescuePayloadOptionsStorage();
+
+		$selected = $transient_storage;
+		if (
+			(
+				function_exists( 'wp_using_ext_object_cache' )
+				&& wp_using_ext_object_cache()
+				&& ! self::transient_is_consistent( $transient_storage )
+			)
+			|| self::transient_links_are_expiring_or_expired( $transient_storage )
+		) {
+			$selected = $options_storage;
+		}
+
+		$filtered = apply_filters( 'llar_mfa_rescue_payload_storage', $selected, $transient_storage, $options_storage );
+		if ( $filtered instanceof RescuePayloadStorageInterface ) {
+			$selected = $filtered;
+		} elseif ( is_string( $filtered ) ) {
+			$choice = strtolower( trim( $filtered ) );
+			if ( 'options' === $choice ) {
+				$selected = $options_storage;
+			} elseif ( 'transient' === $choice ) {
+				$selected = $transient_storage;
+			}
+		}
+
+		self::$selected = $selected;
+		return self::$selected;
+	}
+
+	/**
+	 * Check transient read-after-write consistency.
+	 *
+	 * @param RescuePayloadTransientStorage $storage Transient storage.
+	 * @return bool
+	 */
+	private static function transient_is_consistent( RescuePayloadTransientStorage $storage ) {
+		$probe_hash = 'probe_' . wp_generate_password( 16, false, false );
+		$probe_data = 'ok_' . wp_generate_password( 16, false, false );
+		$saved      = $storage->save( $probe_hash, $probe_data, 30 );
+		$read       = $storage->read( $probe_hash );
+		$exists     = $storage->exists( $probe_hash );
+		$storage->delete( $probe_hash );
+
+		return $saved && $probe_data === $read && $exists;
+	}
+
+	/**
+	 * Check if transient rescue links are expiring soon or already expired.
+	 *
+	 * @param RescuePayloadTransientStorage $storage Transient storage.
+	 * @return bool
+	 */
+	private static function transient_links_are_expiring_or_expired( RescuePayloadTransientStorage $storage ) {
+		$max_expiry = $storage->get_max_expiry();
+		if ( null === $max_expiry ) {
+			return false;
+		}
+
+		$threshold = time() + (int) MfaConstants::RESCUE_NOTICE_THRESHOLD;
+		return (int) $max_expiry <= $threshold;
+	}
+}

--- a/core/mfa/rescuepayloadstorage/RescuePayloadStorageSelector.php
+++ b/core/mfa/rescuepayloadstorage/RescuePayloadStorageSelector.php
@@ -2,8 +2,6 @@
 
 namespace LLAR\Core\Mfa\RescuePayloadStorage;
 
-use LLAR\Core\MfaConstants;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -30,28 +28,37 @@ class RescuePayloadStorageSelector {
 		$transient_storage = new RescuePayloadTransientStorage();
 		$options_storage   = new RescuePayloadOptionsStorage();
 
-		$selected = $transient_storage;
-		if (
-			(
-				function_exists( 'wp_using_ext_object_cache' )
-				&& wp_using_ext_object_cache()
-				&& ! self::transient_is_consistent( $transient_storage )
-			)
-			|| self::transient_links_are_expiring_or_expired( $transient_storage )
-		) {
-			$selected = $options_storage;
+		switch ( true ) {
+			case defined( 'LLA_MFA_FORCE_TRANSIENT_PROVIDER' ) && LLA_MFA_FORCE_TRANSIENT_PROVIDER:
+			case self::is_rescue_link_open_request():
+				// Payload may exist only in transients (e.g. links generated with transient storage); prefer transient on consume even when external object cache would switch writes to options elsewhere.
+				$selected = $transient_storage;
+				break;
+			case ( function_exists( 'wp_using_ext_object_cache' ) && wp_using_ext_object_cache() )
+				|| self::is_rescue_generation_request():
+				$selected = $options_storage;
+				break;
+			default:
+				$selected = $transient_storage;
+				break;
 		}
 
 		$filtered = apply_filters( 'llar_mfa_rescue_payload_storage', $selected, $transient_storage, $options_storage );
-		if ( $filtered instanceof RescuePayloadStorageInterface ) {
-			$selected = $filtered;
-		} elseif ( is_string( $filtered ) ) {
-			$choice = strtolower( trim( $filtered ) );
-			if ( 'options' === $choice ) {
-				$selected = $options_storage;
-			} elseif ( 'transient' === $choice ) {
-				$selected = $transient_storage;
-			}
+		switch ( true ) {
+			case $filtered instanceof RescuePayloadStorageInterface:
+				$selected = $filtered;
+				break;
+			case is_string( $filtered ):
+				$choice = strtolower( trim( $filtered ) );
+				switch ( true ) {
+					case 'options' === $choice:
+						$selected = $options_storage;
+						break;
+					case 'transient' === $choice:
+						$selected = $transient_storage;
+						break;
+				}
+				break;
 		}
 
 		self::$selected = $selected;
@@ -59,35 +66,30 @@ class RescuePayloadStorageSelector {
 	}
 
 	/**
-	 * Check transient read-after-write consistency.
+	 * Whether current request is rescue-links generation.
 	 *
-	 * @param RescuePayloadTransientStorage $storage Transient storage.
 	 * @return bool
 	 */
-	private static function transient_is_consistent( RescuePayloadTransientStorage $storage ) {
-		$probe_hash = 'probe_' . wp_generate_password( 16, false, false );
-		$probe_data = 'ok_' . wp_generate_password( 16, false, false );
-		$saved      = $storage->save( $probe_hash, $probe_data, 30 );
-		$read       = $storage->read( $probe_hash );
-		$exists     = $storage->exists( $probe_hash );
-		$storage->delete( $probe_hash );
-
-		return $saved && $probe_data === $read && $exists;
+	private static function is_rescue_generation_request() {
+		if ( ! function_exists( 'wp_doing_ajax' ) || ! wp_doing_ajax() ) {
+			return false;
+		}
+		$action = isset( $_REQUEST['action'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) : '';
+		return 'llar_mfa_generate_rescue_codes' === $action;
 	}
 
 	/**
-	 * Check if transient rescue links are expiring soon or already expired.
+	 * Whether this HTTP request is opening a rescue link (consumption), not admin AJAX generation.
 	 *
-	 * @param RescuePayloadTransientStorage $storage Transient storage.
 	 * @return bool
 	 */
-	private static function transient_links_are_expiring_or_expired( RescuePayloadTransientStorage $storage ) {
-		$max_expiry = $storage->get_max_expiry();
-		if ( null === $max_expiry ) {
+	private static function is_rescue_link_open_request() {
+		if ( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
 			return false;
 		}
-
-		$threshold = time() + (int) MfaConstants::RESCUE_NOTICE_THRESHOLD;
-		return (int) $max_expiry <= $threshold;
+		if ( isset( $_GET['llar_rescue'] ) && is_string( $_GET['llar_rescue'] ) && '' !== $_GET['llar_rescue'] ) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/core/mfa/rescuepayloadstorage/RescuePayloadTransientStorage.php
+++ b/core/mfa/rescuepayloadstorage/RescuePayloadTransientStorage.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace LLAR\Core\Mfa\RescuePayloadStorage;
+
+use LLAR\Core\MfaConstants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Rescue payload storage backed by WordPress transients.
+ */
+class RescuePayloadTransientStorage implements RescuePayloadStorageInterface {
+	/**
+	 * @param string $hash_id Rescue hash token.
+	 * @return string
+	 */
+	private function get_transient_key( $hash_id ) {
+		return MfaConstants::TRANSIENT_RESCUE_PREFIX . $hash_id;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save( $hash_id, $encrypted, $ttl ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id || '' === (string) $encrypted ) {
+			return false;
+		}
+		return (bool) set_transient( $this->get_transient_key( $hash_id ), (string) $encrypted, (int) $ttl );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function read( $hash_id ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id ) {
+			return false;
+		}
+		$transient_key = $this->get_transient_key( $hash_id );
+		$data          = get_transient( $transient_key );
+		if ( false !== $data ) {
+			return $data;
+		}
+
+		global $wpdb;
+		$option_name = '_transient_' . $transient_key;
+		$raw         = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT option_value FROM ' . $wpdb->options . ' WHERE option_name = %s LIMIT 1',
+				$option_name
+			)
+		);
+		if ( null !== $raw && '' !== $raw ) {
+			$data = maybe_unserialize( $raw );
+		}
+		return false === $data ? false : $data;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function delete( $hash_id ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id ) {
+			return false;
+		}
+		$transient_key = $this->get_transient_key( $hash_id );
+		$existed       = $this->exists( $hash_id );
+
+		delete_transient( $transient_key );
+
+		global $wpdb;
+		$option_name  = '_transient_' . $transient_key;
+		$timeout_name = '_transient_timeout_' . $transient_key;
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name = %s', $option_name ) );
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name = %s', $timeout_name ) );
+
+		delete_transient( MfaConstants::RESCUE_MAX_EXPIRY_CACHE_KEY );
+
+		return $existed;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function exists( $hash_id ) {
+		$hash_id = (string) $hash_id;
+		if ( '' === $hash_id ) {
+			return false;
+		}
+		$transient_key = $this->get_transient_key( $hash_id );
+		if ( false !== get_transient( $transient_key ) ) {
+			return true;
+		}
+
+		global $wpdb;
+		$option_name = '_transient_' . $transient_key;
+		$one         = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT 1 FROM ' . $wpdb->options . ' WHERE option_name = %s LIMIT 1',
+				$option_name
+			)
+		);
+		return null !== $one;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_max_expiry() {
+		global $wpdb;
+		$timeout_like = $wpdb->esc_like( '_transient_timeout_' . MfaConstants::TRANSIENT_RESCUE_PREFIX ) . '%';
+		$max_timeout  = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT MAX(CAST(option_value AS UNSIGNED)) FROM ' . $wpdb->options . ' WHERE option_name LIKE %s',
+				$timeout_like
+			)
+		);
+		if ( 0 === $max_timeout ) {
+			return null;
+		}
+		return $max_timeout;
+	}
+}


### PR DESCRIPTION
## Summary

Adds dedicated rescue-link payload storage behind an interface with transient and wp_options (non-autoload) implementations plus a selector. Aligns creation vs consumption paths so links remain usable across external object cache and mixed-provider setups.

## Changes

- Inject shared storage into MFA backup codes, endpoint, and manager.
- Selector chooses transient vs options using force constant, rescue consumption vs AJAX generation, object cache, and filter override.
- Endpoint reads and deletes payloads across primary and opposite-provider fallback.
- Admin notice TTL resolves max expiry from the alternate provider when the primary reports none.