### PR TITLE
fix(mfa): use root path for MFA state cookie to support custom login URLs

### DIFF
--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -2078,7 +2078,7 @@ class LimitLoginAttempts
 				$remember_me
 			);
 			$store->save_callback_state( $state, $result['data']['token'] );
-			setcookie( 'llar_mfa_state', $state, time() + 600, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+			\LLAR\Core\MfaFlow\SessionStore::set_state_cookie( $state );
 			$mfa_redirect_url = esc_url_raw( $redirect_url_value );
 			if ( $mfa_redirect_url ) {
 				self::mfa_redirect_to_url( $mfa_redirect_url );

--- a/core/mfa-flow/CallbackHandler.php
+++ b/core/mfa-flow/CallbackHandler.php
@@ -126,7 +126,7 @@ class CallbackHandler {
 			return;
 		}
 		$verify = $store->consume_callback_state( $cookie, $token );
-		setcookie( 'llar_mfa_state', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+		SessionStore::set_state_cookie( '' );
 		if ( ! $verify ) {
 			$store->delete_session( $token );
 			self::redirect_login( 'llar_mfa_session_expired' );
@@ -177,7 +177,7 @@ class CallbackHandler {
 			return;
 		}
 		$verify = $store->consume_callback_state( $cookie, $token );
-		setcookie( 'llar_mfa_state', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+		SessionStore::set_state_cookie( '' );
 		if ( ! $verify ) {
 			$store->delete_session( $token );
 			self::redirect_login( 'llar_mfa_session_expired' );

--- a/core/mfa-flow/SessionStore.php
+++ b/core/mfa-flow/SessionStore.php
@@ -14,6 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SessionStore {
 
 	/**
+	 * Set or clear the MFA state cookie.
+	 *
+	 * @param string $value State value; empty string clears the cookie.
+	 */
+	public static function set_state_cookie( $value ) {
+		$expire = ( '' === $value ) ? time() - 3600 : time() + 600;
+		setcookie( 'llar_mfa_state', $value, $expire, '/', '', is_ssl(), true );
+	}
+
+	/**
 	 * Save session after handshake.
 	 *
 	 * @param string $token       From API.


### PR DESCRIPTION
## Summary

- MFA state cookie was set with `COOKIEPATH`/`COOKIE_DOMAIN`, which may not cover custom login URL paths (Perfmatters, WPS Hide Login, etc.), causing the browser to silently drop the cookie on MFA callback — resulting in `llar_mfa_session_expired` error.
- Replace with `'/'` and empty domain for broadest cookie visibility. The cookie is short-lived (10 min), HttpOnly, Secure, and contains only a random CSRF state value.
- Extract `SessionStore::set_state_cookie()` to centralize cookie handling (DRY).

## Affected files

- `core/mfa-flow/SessionStore.php` — new static method `set_state_cookie()`
- `core/LimitLoginAttempts.php` — use `set_state_cookie()` when setting state
- `core/mfa-flow/CallbackHandler.php` — use `set_state_cookie('')` when clearing state (2 places)