### PR TITLE
fix(lockouts): use correct option key in local logs view

### DIFF
--- a/core/Ajax.php
+++ b/core/Ajax.php
@@ -54,16 +54,16 @@ class Ajax
 		check_ajax_referer( 'llar-unlock', 'sec' );
 		$ip = (string) @$_POST['ip'];
 
-		$lockouts = (array) Config::get( 'lockouts' );
+		$lockouts = (array) Config::get( Config::OPTION_LOCKOUTS );
 
 		if ( isset( $lockouts[ $ip ] ) ) {
 			unset( $lockouts[ $ip ] );
-			Config::update( 'lockouts', $lockouts );
+			Config::update( Config::OPTION_LOCKOUTS, $lockouts );
 		}
 
 		//save to log
 		$user_login = @(string) $_POST['username'];
-		$log        = Config::get( 'logged' );
+		$log        = Config::get( Config::OPTION_LOGGED );
 
 		if ( @$log[ $ip ][ $user_login ] ) {
 			if ( ! is_array( $log[ $ip ][ $user_login ] ) ) {
@@ -73,7 +73,7 @@ class Ajax
 			}
 			$log[ $ip ][ $user_login ]['unlocked'] = true;
 
-			Config::update( 'logged', $log );
+			Config::update( Config::OPTION_LOGGED, $log );
 		}
 
 		header( 'Content-Type: application/json' );
@@ -1007,7 +1007,7 @@ class Ajax
 
         check_ajax_referer( 'llar-action-onboarding-reset', 'sec' );
 
-        if ( Config::get( 'active_app' ) !== 'local' || ! empty( Config::get( 'app_setup_code' ) ) ) {
+        if ( Config::get( Config::OPTION_ACTIVE_APP ) !== 'local' || ! empty( Config::get( 'app_setup_code' ) ) ) {
 
             wp_send_json_error( array() );
         }

--- a/core/CloudApp.php
+++ b/core/CloudApp.php
@@ -155,7 +155,7 @@ class CloudApp
 
 				Helpers::cloud_app_update_config( $setup_result['app_config'], true );
 
-				Config::update( 'active_app', 'custom' );
+				Config::update( Config::OPTION_ACTIVE_APP, 'custom' );
 				Config::update( 'app_setup_code', $setup_code );
 
 				$setup_result['app_config']['messages']['setup_success'] =

--- a/core/Config.php
+++ b/core/Config.php
@@ -8,6 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Config {
 
+	const OPTION_LOCKOUTS   = 'lockouts';
+	const OPTION_LOGGED     = 'logged';
+	const OPTION_ACTIVE_APP = 'active_app';
+
 	private static $default_options = array(
 		'gdpr'                          => 0,
 		'gdpr_message'                  => '',

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -720,7 +720,7 @@ class LimitLoginAttempts
 		if ( Config::get( 'onboarding_popup_shown' ) ) {
 			return;
 		}
-		if ( 'custom' === Config::get( 'active_app' ) && self::$cloud_app ) {
+		if ( 'custom' === Config::get( Config::OPTION_ACTIVE_APP ) && self::$cloud_app ) {
 			return;
 		}
 		if ( ! empty( Config::get( 'app_setup_code' ) ) ) {
@@ -872,7 +872,7 @@ class LimitLoginAttempts
 		// Same error output as failed login for any MFA redirect (session_expired, code_invalid, etc.).
 		$show_mfa_return_error = ( $llar_mfa_error !== '' );
 
-		if ( Config::get( 'active_app' ) === 'local' && ! $limit_login_nonempty_credentials && ! $show_mfa_return_error ) {
+		if ( Config::get( Config::OPTION_ACTIVE_APP ) === 'local' && ! $limit_login_nonempty_credentials && ! $show_mfa_return_error ) {
 			return;
 		}
 
@@ -981,7 +981,7 @@ class LimitLoginAttempts
 			'<a href="' . $this->get_options_page_uri( 'settings' ) . '">' . __( 'Settings', 'limit-login-attempts-reloaded' ) . '</a>',
 		), $actions );
 
-		if ( Config::get( 'active_app' ) === 'local' ) {
+		if ( Config::get( Config::OPTION_ACTIVE_APP ) === 'local' ) {
 
 			if ( empty( Config::get( 'app_setup_code' ) ) ) {
 
@@ -1023,7 +1023,7 @@ class LimitLoginAttempts
 
 	public function cloud_app_init()
 	{
-		if ( Config::get( 'active_app' ) === 'custom' && $config = Config::get( 'app_config' ) ) {
+		if ( Config::get( Config::OPTION_ACTIVE_APP ) === 'custom' && $config = Config::get( 'app_config' ) ) {
 
 			self::$cloud_app = new CloudApp( $config );
 		}
@@ -1603,7 +1603,7 @@ class LimitLoginAttempts
 
 	private function get_submenu_items()
 	{
-		$active_app        = Config::get( 'active_app' );
+		$active_app        = Config::get( Config::OPTION_ACTIVE_APP );
 		$app_setup_code    = Config::get( 'app_setup_code' );
 		$is_cloud_app_enabled = $active_app === 'custom';
 		$is_local_empty_setup_code = ( $active_app === 'local' && empty( $app_setup_code ) );
@@ -1681,7 +1681,7 @@ class LimitLoginAttempts
 				74
 			);
 
-			$is_cloud_app_enabled = Config::get( 'active_app' ) === 'custom';
+			$is_cloud_app_enabled = Config::get( Config::OPTION_ACTIVE_APP ) === 'custom';
 			$submenu_items = $this->get_submenu_items();
 
 			$index = 1;
@@ -1763,7 +1763,7 @@ class LimitLoginAttempts
 
 		if (
 			! empty( $_COOKIE['llar_menu_alert_icon_shown'] )
-			|| Config::get( 'active_app' ) !== 'local'
+			|| Config::get( Config::OPTION_ACTIVE_APP ) !== 'local'
 			|| ! Config::get( 'show_warning_badge' )
 		) {
 			return '';
@@ -1890,7 +1890,7 @@ class LimitLoginAttempts
 		}
 
 		/* lockout active? */
-		$lockouts = Config::get( 'lockouts' );
+		$lockouts = Config::get( Config::OPTION_LOCKOUTS );
 
 		return ( ! is_array( $lockouts ) || ! isset( $lockouts[ $ip ] ) || time() >= $lockouts[ $ip ] );
 	}
@@ -2144,7 +2144,7 @@ class LimitLoginAttempts
 			$ip = $this->get_address();
 
 			/* if currently locked-out, do not add to retries */
-			$lockouts = Config::get( 'lockouts' );
+			$lockouts = Config::get( Config::OPTION_LOCKOUTS );
 
 			if ( ! is_array( $lockouts ) ) {
 				$lockouts = array();
@@ -2424,7 +2424,7 @@ class LimitLoginAttempts
 			return;
 		}
 
-		$log = $option = Config::get( 'logged' );
+		$log = $option = Config::get( Config::OPTION_LOGGED );
 
 		if ( ! is_array( $log ) ) {
 			$log = array();
@@ -2454,7 +2454,7 @@ class LimitLoginAttempts
 			Config::add( 'logged', $log );
 		} else {
 
-			Config::update( 'logged', $log );
+			Config::update( Config::OPTION_LOGGED, $log );
 		}
 	}
 
@@ -2651,7 +2651,7 @@ class LimitLoginAttempts
 	public function error_msg()
 	{
 		$ip       = $this->get_address();
-		$lockouts = Config::get( 'lockouts' );
+		$lockouts = Config::get( Config::OPTION_LOCKOUTS );
 		$a        = $this->checkKey($lockouts, $ip);
 		$b        = $this->checkKey($lockouts, $this->getHash($ip));
 
@@ -2862,9 +2862,9 @@ class LimitLoginAttempts
 	public function cleanup( $retries = null, $lockouts = null, $valid = null )
 	{
 		$now      = time();
-		$lockouts = ! is_null( $lockouts ) ? $lockouts : Config::get( 'lockouts' );
+		$lockouts = ! is_null( $lockouts ) ? $lockouts : Config::get( Config::OPTION_LOCKOUTS );
 
-		$log = Config::get( 'logged' );
+		$log = Config::get( Config::OPTION_LOGGED );
 
 		/* remove old lockouts */
 		if ( is_array( $lockouts ) ) {
@@ -2883,10 +2883,10 @@ class LimitLoginAttempts
 					}
 				}
 			}
-			Config::update( 'lockouts', $lockouts );
+			Config::update( Config::OPTION_LOCKOUTS, $lockouts );
 		}
 
-		Config::update( 'logged', $log );
+		Config::update( Config::OPTION_LOGGED, $log );
 
 		/* remove retries that are no longer valid */
 		$valid   = ! is_null( $valid ) ? $valid : Config::get( 'retries_valid' );
@@ -2958,7 +2958,7 @@ class LimitLoginAttempts
 			/* Should we clear log? */
 			if ( isset( $_POST[ 'clear_log' ] ) ) {
 
-				Config::update( 'logged', array() );
+				Config::update( Config::OPTION_LOGGED, array() );
 				$this->show_message( __( 'Cleared IP log', 'limit-login-attempts-reloaded' ) );
 			}
 
@@ -2972,7 +2972,7 @@ class LimitLoginAttempts
 			/* Should we restore current lockouts? */
 			if ( isset( $_POST[ 'reset_current' ] ) ) {
 
-				Config::update( 'lockouts', array() );
+				Config::update( Config::OPTION_LOCKOUTS, array() );
 				$this->show_message( __( 'Cleared current lockouts', 'limit-login-attempts-reloaded' ) );
 			}
 
@@ -3073,7 +3073,7 @@ class LimitLoginAttempts
 				Config::update('custom_error_message',      sanitize_textarea_field( Helpers::deslash( $_POST['custom_error_message'] ) ) );
 				Config::update('admin_notify_email',        sanitize_email( $_POST['admin_notify_email'] ) );
 
-				Config::update('active_app', sanitize_text_field( $_POST['active_app'] ) );
+				Config::update( Config::OPTION_ACTIVE_APP, sanitize_text_field( $_POST['active_app'] ) );
 
 				$trusted_ip_origins = ( ! empty( $_POST['lla_trusted_ip_origins'] ) )
 					? array_map( 'trim', explode( ',', sanitize_text_field( $_POST['lla_trusted_ip_origins'] ) ) )
@@ -3647,7 +3647,7 @@ class LimitLoginAttempts
 			@setcookie( 'llar_enable_notify_notice_shown', '', time() - 3600, '/' );
 		}
 
-		$active_app = Config::get( 'active_app' );
+		$active_app = Config::get( Config::OPTION_ACTIVE_APP );
 		$notify_methods = explode( ',', Config::get( 'lockout_notify' ) );
 
 		if (

--- a/views/admin-dashboard-widgets.php
+++ b/views/admin-dashboard-widgets.php
@@ -9,7 +9,7 @@ use LLAR\Core\LimitLoginAttempts;
 
 if ( ! defined( 'ABSPATH' ) ) exit();
 
-$active_app = ( Config::get( 'active_app' ) === 'custom' && LimitLoginAttempts::$cloud_app ) ? 'custom' : 'local';
+$active_app = ( Config::get( Config::OPTION_ACTIVE_APP ) === 'custom' && LimitLoginAttempts::$cloud_app ) ? 'custom' : 'local';
 $is_active_app_custom = $active_app === 'custom';
 
 if ( $is_active_app_custom ) {

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -16,7 +16,7 @@ if ( $active_tab === 'logs-custom' && ! LimitLoginAttempts::$cloud_app ) {
 	$active_tab = 'logs-local';
 }
 
-$active_app = ( Config::get( 'active_app' ) === 'custom' && LimitLoginAttempts::$cloud_app ) ? 'custom' : 'local';
+$active_app = ( Config::get( Config::OPTION_ACTIVE_APP ) === 'custom' && LimitLoginAttempts::$cloud_app ) ? 'custom' : 'local';
 $is_active_app_custom = $active_app === 'custom';
 
 $auto_update_choice = Config::get( 'auto_update_choice' );

--- a/views/tab-debug.php
+++ b/views/tab-debug.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
 
-$active_app = Config::get( 'active_app' );
+$active_app = Config::get( Config::OPTION_ACTIVE_APP );
 $active_app = ( $active_app === 'custom' && LimitLoginAttempts::$cloud_app ) ? 'custom' : 'local';
 $setup_code = Config::get( 'app_setup_code' );
 

--- a/views/tab-logs-local.php
+++ b/views/tab-logs-local.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) exit();
  */
 
 $lockouts_total = Config::get( 'lockouts_total' );
-$lockouts = Config::get( 'login_lockouts' );
+$lockouts = Config::get( Config::OPTION_LOCKOUTS );
 $lockouts_now = is_array( $lockouts ) ? count( $lockouts ) : 0;
 
 $white_list_ips = Config::get( 'whitelist' );
@@ -184,9 +184,9 @@ $url_try_for_free = 'https://www.limitloginattempts.com/upgrade/?from=plugin-';
     </div>
 
     <?php
-    $log = Config::get( 'logged' );
+    $log = Config::get( Config::OPTION_LOGGED );
     $log = Helpers::sorted_log_by_date( $log );
-    $lockouts = (array) Config::get( 'lockouts' );
+    $lockouts = (array) Config::get( Config::OPTION_LOCKOUTS );
 
     if ( is_array( $log ) && ! empty( $log ) ) : ?>
         <h3 class="title_page">


### PR DESCRIPTION
## Summary

- **Bug**: `views/tab-logs-local.php` read `Config::get('login_lockouts')` — a key that does not exist. The correct key is `'lockouts'`. This caused the active lockout count to always show as 0 in the local mode UI, making it impossible to see or unlock blocked IPs after switching from Cloud to Local mode.
- **Refactor**: Extract `Config::OPTION_LOCKOUTS`, `Config::OPTION_LOGGED`, and `Config::OPTION_ACTIVE_APP` constants. All string-based usages of these keys across 8 files are replaced with the constants — any future typo will now trigger a PHP fatal error instead of silently returning null.

## Affected files

- `core/Config.php` — 3 new class constants
- `core/LimitLoginAttempts.php` — 15 replacements
- `core/Ajax.php` — 5 replacements
- `core/CloudApp.php` — 1 replacement
- `views/tab-logs-local.php` — 3 replacements (including the bug fix)
- `views/tab-debug.php` — 1 replacement
- `views/options-page.php` — 1 replacement
- `views/admin-dashboard-widgets.php` — 1 replacement