### PR TITLE
fix: WP 7.0 auth compatibility layer (wp-login.php)

### DIFF
--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -133,6 +133,52 @@ class LimitLoginAttempts
 	private static $mfa_flow_handshake_attempted = false;
 
 	/**
+	 * Guard: failed login already recorded in this request.
+	 *
+	 * @temporary WP 7.0 compat — not reset between requests in persistent runtimes (Swoole/FrankenPHP).
+	 *            Add reset via `init` hook if such environments need support.
+	 *
+	 * @var bool
+	 */
+	private static $failed_login_recorded_in_request = false;
+
+	/**
+	 * @temporary WP 7.0 compat — single source of truth for auth failure WP_Error codes.
+	 *
+	 * @var array
+	 */
+	private static $auth_failure_codes = array( 'invalid_username', 'invalid_email', 'incorrect_password', 'authentication_failed' );
+
+	/**
+	 * Cached results of WP version checks.
+	 *
+	 * @var array
+	 */
+	private static $wp_version_cache = array();
+
+	/**
+	 * Check whether the current WordPress version is at least $version. Result is cached.
+	 *
+	 * @param string $version Minimum version to compare against (e.g. '6.9', '7.0').
+	 * @return bool
+	 */
+	private static function is_wp_at_least( $version ) {
+		if ( ! isset( self::$wp_version_cache[ $version ] ) ) {
+			self::$wp_version_cache[ $version ] = version_compare( Helpers::get_wordpress_version(), $version, '>=' );
+		}
+		return self::$wp_version_cache[ $version ];
+	}
+
+	/**
+	 * @temporary WP 7.0 compat — reset per-request static guards.
+	 *            Needed only in persistent PHP runtimes (Swoole, FrankenPHP).
+	 *            $wp_version_cache is intentionally NOT reset — WP version does not change between requests.
+	 */
+	public static function reset_request_guards() {
+		self::$failed_login_recorded_in_request = false;
+	}
+
+	/**
 	 * Allowed tabs for options page
 	 */
 	public static $allowed_tabs = array( 'logs-local', 'logs-custom', 'settings', 'mfa', 'debug', 'premium', 'help' );
@@ -746,12 +792,17 @@ class LimitLoginAttempts
 			Config::update( 'notice_enable_notify_timestamp', strtotime( '-32 day' ) );
 		}
 
-		if ( version_compare( Helpers::get_wordpress_version(), '5.5', '<' ) ) {
+		if ( ! self::is_wp_at_least( '5.5' ) ) {
 			Config::update( 'auto_update_choice', 0 );
 		}
 
 		// Load translations and defaults in a WP-version-safe way.
 		add_action( 'init', array( $this, 'load_plugin_textdomain_in_time' ) );
+
+		// @temporary WP 7.0 compat — reset per-request guard for persistent runtimes (Swoole/FrankenPHP).
+		if ( self::is_wp_at_least( '7.0' ) ) {
+			add_action( 'init', array( __CLASS__, 'reset_request_guards' ), 0 );
+		}
 
 		$this->register_mfa_providers();
 
@@ -792,10 +843,9 @@ class LimitLoginAttempts
 		add_filter( 'xmlrpc_login_error', array( $this, 'xmlrpc_error_messages' ) );
 
 		/*
-		* This action should really be changed to the 'authenticate' filter as
-		* it will probably be deprecated. That is however only available in
-		* later versions of WP.
-		*/
+		 * Primary auth chain: guard at lowest priority, then early ACL/blacklist,
+		 * credentials tracking, late error fallback, and final lockout safety net.
+		 */
 		add_filter( 'authenticate', array( $this, 'authenticate_guard_filter' ), -9999, 3 );
 		add_action( 'authenticate', array( $this, 'track_credentials' ), 1, 3 ); // to replace the deprecated wp_authenticate hook
 		add_action( 'authenticate', array( $this, 'authenticate_filter' ), 0, 3 );
@@ -805,6 +855,11 @@ class LimitLoginAttempts
 		 * Wordfence error message fix
 		 */
 		add_action( 'authenticate', array( $this, 'authenticate_filter_errors_fix' ), 35, 3 );
+
+		// @temporary WP 7.0 compat — late safety net; re-evaluate after WP 7.0 auth flow stabilizes.
+		if ( self::is_wp_at_least( '7.0' ) ) {
+			add_filter( 'authenticate', array( $this, 'authenticate_late_lockout_check' ), 99990, 3 );
+		}
 
 		add_filter( 'plugin_action_links_' . LLA_PLUGIN_BASENAME, array( $this, 'add_action_links' ) );
 
@@ -835,8 +890,8 @@ class LimitLoginAttempts
 	 */
 	public function load_plugin_textdomain_in_time()
 	{
-		if ( version_compare( Helpers::get_wordpress_version(), '6.9', '<' ) && function_exists( 'load_plugin_textdomain' ) ) {
-			load_plugin_textdomain( 'limit-login-attempts-reloaded', false, plugin_basename( __DIR__ ) . '/../languages' );
+		if ( ! self::is_wp_at_least( '6.9' ) ) {
+			load_plugin_textdomain( 'limit-login-attempts-reloaded', false, basename( LLA_PLUGIN_DIR ) . '/languages' );
 		}
 
 		Config::init_defaults();
@@ -1120,12 +1175,16 @@ class LimitLoginAttempts
 			if ( self::$cloud_app && $response = $this->get_auth_acl_response( $username ) ) {
 				if ( 'pass' === $response['result'] ) {
 					remove_filter( 'login_errors', array( $this, 'fixup_error_messages' ) );
-					// Keep wp_login_failed when MFA is enabled (and not temporarily disabled) so limit_login_failed runs (handshake + redirect to MFA app).
-					$mfa_effectively_enabled = Config::get( 'mfa_enabled' ) && ( false === get_transient( MfaConstants::TRANSIENT_MFA_DISABLED ) );
-					if ( ! $mfa_effectively_enabled ) {
-						remove_filter( 'wp_login_failed', array( $this, 'limit_login_failed' ) );
+
+					// @temporary WP 7.0 compat — on WP 7.0+ keep all hooks active; late safety net handles recording and lockout.
+					// On older WP, preserve original hook removal logic.
+					if ( ! self::is_wp_at_least( '7.0' ) ) {
+						$mfa_effectively_enabled = Config::get( 'mfa_enabled' ) && ( false === get_transient( MfaConstants::TRANSIENT_MFA_DISABLED ) );
+						if ( ! $mfa_effectively_enabled ) {
+							remove_filter( 'wp_login_failed', array( $this, 'limit_login_failed' ) );
+						}
+						remove_filter( 'wp_authenticate_user', array( $this, 'wp_authenticate_user' ), 99999 );
 					}
-					remove_filter( 'wp_authenticate_user', array( $this, 'wp_authenticate_user' ), 99999 );
 				}
 			} else {
 
@@ -1469,6 +1528,17 @@ class LimitLoginAttempts
 
 			if ( is_wp_error( $user ) ) {
 
+				// @temporary WP 7.0 compat — fallback recording for auth flows where wp_login_failed is unreliable.
+				if ( self::is_wp_at_least( '7.0' ) ) {
+					$error_codes = $user->get_error_codes();
+					if (
+						! self::$failed_login_recorded_in_request
+						&& array_intersect( self::$auth_failure_codes, $error_codes )
+					) {
+						$this->record_failed_login_attempt( $username );
+					}
+				}
+
 				// BuddyPress errors
 				if ( in_array('bp_account_not_activated', $user->get_error_codes() ) ) {
 
@@ -1480,6 +1550,68 @@ class LimitLoginAttempts
 			}
 
 		}
+		return $user;
+	}
+
+	/**
+	 * Late authenticate safety net for WP 7.0+ compatibility.
+	 *
+	 * @temporary Re-evaluate after WP 7.0 auth flow stabilizes.
+	 *
+	 * Runs at a very high priority on the authenticate filter to catch
+	 * failed logins that were not recorded by earlier hooks (e.g. when
+	 * wp_login_failed does not fire or core auth runs at changed priorities)
+	 * and to enforce lockout even when the wp_authenticate_user filter
+	 * inside wp_authenticate_username_password is not reached.
+	 *
+	 * @param mixed  $user
+	 * @param string $username
+	 * @param string $password
+	 * @return mixed
+	 */
+	public function authenticate_late_lockout_check( $user, $username, $password ) {
+		if ( empty( $username ) || empty( $password ) ) {
+			return $user;
+		}
+
+		// Successful auth already validated by earlier guards — do not override.
+		if ( $user instanceof \WP_User ) {
+			return $user;
+		}
+
+		if ( is_wp_error( $user ) ) {
+			$error_codes = $user->get_error_codes();
+
+			if (
+				in_array( 'too_many_retries', $error_codes, true )
+				|| in_array( 'username_blacklisted', $error_codes, true )
+			) {
+				return $user;
+			}
+
+			if ( ! self::$failed_login_recorded_in_request ) {
+				if ( array_intersect( self::$auth_failure_codes, $error_codes ) ) {
+					$this->record_failed_login_attempt( $username );
+				}
+			}
+		}
+
+		$ip = $this->get_address();
+		if (
+			! $this->is_ip_whitelisted( $ip )
+			&& ! $this->is_username_whitelisted( $username )
+			&& ! $this->is_limit_login_ok()
+		) {
+			global $limit_login_my_error_shown;
+			$limit_login_my_error_shown = true;
+
+			$error = new WP_Error();
+			$error->add( 'too_many_retries', $this->error_msg() );
+			LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
+
+			return $error;
+		}
+
 		return $user;
 	}
 
@@ -2100,6 +2232,8 @@ class LimitLoginAttempts
 	 * @param string $username Login username.
 	 */
 	private function record_failed_login_attempt( $username ) {
+		self::$failed_login_recorded_in_request = true;
+
 		LoginFlowTransientStore::ensure_token();
 		LoginFlowTransientStore::merge( array( 'login_attempts_left' => 0 ) );
 
@@ -2123,6 +2257,14 @@ class LimitLoginAttempts
 				$err = __( '<strong>ERROR</strong>: Too many failed login attempts.', 'limit-login-attempts-reloaded' );
 
 				$time_left = ( ! empty( $response['time_left'] ) ) ? $response['time_left'] : 0;
+
+				// @temporary WP 7.0 compat — mirror cloud deny in local lockouts so is_limit_login_ok() blocks consistently.
+				if ( $time_left > 0 ) {
+					$lockouts       = Config::get( 'lockouts' );
+					$lockouts       = is_array( $lockouts ) ? $lockouts : array();
+					$lockouts[ $ip ] = time() + ( (int) $time_left * MINUTE_IN_SECONDS );
+					Config::update( 'lockouts', $lockouts );
+				}
 
 				if ( $time_left > 60 ) {
 
@@ -2266,6 +2408,11 @@ class LimitLoginAttempts
 	 * @param string $username Login username.
 	 */
 	public function limit_login_failed( $username ) {
+		// @temporary WP 7.0 compat — prevent double-recording when late authenticate fallback already fired.
+		if ( self::$failed_login_recorded_in_request ) {
+			return;
+		}
+
 		$this->record_failed_login_attempt( $username );
 	}
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -164,7 +164,8 @@ class LimitLoginAttempts
 	 */
 	private static function is_wp_at_least( $version ) {
 		if ( ! isset( self::$wp_version_cache[ $version ] ) ) {
-			self::$wp_version_cache[ $version ] = version_compare( Helpers::get_wordpress_version(), $version, '>=' );
+			$current = preg_replace( '/[^0-9.].*/', '', Helpers::get_wordpress_version() );
+			self::$wp_version_cache[ $version ] = version_compare( $current, $version, '>=' );
 		}
 		return self::$wp_version_cache[ $version ];
 	}

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -134,16 +134,22 @@ class LimitLoginAttempts
 
 	/**
 	 * Guard: failed login already recorded in this request.
-	 *
-	 * @temporary WP 7.0 compat — not reset between requests in persistent runtimes (Swoole/FrankenPHP).
-	 *            Add reset via `init` hook if such environments need support.
+	 * Reset on each `init` for persistent runtimes (Swoole/FrankenPHP).
 	 *
 	 * @var bool
 	 */
 	private static $failed_login_recorded_in_request = false;
 
 	/**
+	 * Priority for the late authenticate safety net.
+	 *
+	 * @temporary WP 7.0 compat — remove after WP 7.1 release or when auth flow is stable.
+	 */
+	const LATE_AUTH_PRIORITY = 99990;
+
+	/**
 	 * @temporary WP 7.0 compat — single source of truth for auth failure WP_Error codes.
+	 * TODO: Remove after WP 7.1 release or when auth flow is stable.
 	 *
 	 * @var array
 	 */
@@ -171,9 +177,8 @@ class LimitLoginAttempts
 	}
 
 	/**
-	 * @temporary WP 7.0 compat — reset per-request static guards.
-	 *            Needed only in persistent PHP runtimes (Swoole, FrankenPHP).
-	 *            $wp_version_cache is intentionally NOT reset — WP version does not change between requests.
+	 * Reset per-request static guards for persistent PHP runtimes (Swoole, FrankenPHP).
+	 * $wp_version_cache is intentionally NOT reset — WP version does not change between requests.
 	 */
 	public static function reset_request_guards() {
 		self::$failed_login_recorded_in_request = false;
@@ -801,10 +806,8 @@ class LimitLoginAttempts
 		// Load translations and defaults in a WP-version-safe way.
 		add_action( 'init', array( $this, 'load_plugin_textdomain_in_time' ) );
 
-		// @temporary WP 7.0 compat — reset per-request guard for persistent runtimes (Swoole/FrankenPHP).
-		if ( self::is_wp_at_least( '7.0' ) ) {
-			add_action( 'init', array( __CLASS__, 'reset_request_guards' ), 0 );
-		}
+		// Reset per-request static guards for persistent runtimes (Swoole/FrankenPHP).
+		add_action( 'init', array( __CLASS__, 'reset_request_guards' ), 0 );
 
 		$this->register_mfa_providers();
 
@@ -858,9 +861,10 @@ class LimitLoginAttempts
 		 */
 		add_action( 'authenticate', array( $this, 'authenticate_filter_errors_fix' ), 35, 3 );
 
-		// @temporary WP 7.0 compat — late safety net; re-evaluate after WP 7.0 auth flow stabilizes.
+		// @temporary WP 7.0 compat — late safety net.
+		// TODO: Remove after WP 7.1 release or when auth flow is stable.
 		if ( self::is_wp_at_least( '7.0' ) ) {
-			add_filter( 'authenticate', array( $this, 'authenticate_late_lockout_check' ), 99990, 3 );
+			add_filter( 'authenticate', array( $this, 'authenticate_late_lockout_check' ), self::LATE_AUTH_PRIORITY, 3 );
 		}
 
 		add_filter( 'plugin_action_links_' . LLA_PLUGIN_BASENAME, array( $this, 'add_action_links' ) );
@@ -1179,6 +1183,7 @@ class LimitLoginAttempts
 					remove_filter( 'login_errors', array( $this, 'fixup_error_messages' ) );
 
 					// @temporary WP 7.0 compat — on WP 7.0+ keep all hooks active; late safety net handles recording and lockout.
+					// TODO: Remove after WP 7.1 release or when auth flow is stable.
 					// On older WP, preserve original hook removal logic.
 					if ( ! self::is_wp_at_least( '7.0' ) ) {
 						$mfa_effectively_enabled = Config::get( 'mfa_enabled' ) && ( false === get_transient( MfaConstants::TRANSIENT_MFA_DISABLED ) );
@@ -1531,6 +1536,7 @@ class LimitLoginAttempts
 			if ( is_wp_error( $user ) ) {
 
 				// @temporary WP 7.0 compat — fallback recording for auth flows where wp_login_failed is unreliable.
+				// TODO: Remove after WP 7.1 release or when auth flow is stable.
 				if ( self::is_wp_at_least( '7.0' ) ) {
 					$error_codes = $user->get_error_codes();
 					if (
@@ -1558,7 +1564,7 @@ class LimitLoginAttempts
 	/**
 	 * Late authenticate safety net for WP 7.0+ compatibility.
 	 *
-	 * @temporary Re-evaluate after WP 7.0 auth flow stabilizes.
+	 * @temporary WP 7.0 compat — remove after WP 7.1 release or when auth flow is stable.
 	 *
 	 * Runs at a very high priority on the authenticate filter to catch
 	 * failed logins that were not recorded by earlier hooks (e.g. when
@@ -2063,9 +2069,9 @@ class LimitLoginAttempts
 	 * to track credentials and check lockouts before MemberPress validates the password
 	 * This enables the plugin to display remaining attempts messages
 	 *
-	 * @param array $errors Array of existing errors
+	 * @param array $errors Array of existing errors (MemberPress passes validate_login output first).
 	 * @param array $params Login parameters (log, pwd)
-	 * @return array Unchanged errors array (we don't block, only track)
+	 * @return array Errors for MemberPress; when LLAR blocks login, returns that message as first error.
 	 */
 	public function mepr_validate_login_handler( $errors, $params = array() )
 	{
@@ -2076,12 +2082,23 @@ class LimitLoginAttempts
 		$log = sanitize_text_field( wp_unslash( $_POST['log'] ) );
 		$pwd = isset( $_POST['pwd'] ) ? $_POST['pwd'] : ''; // Password should not be sanitized
 
-		// Trigger authenticate filter to track credentials and check lockouts
-		// This sets $limit_login_nonempty_credentials and login_attempts_left in LoginFlowTransientStore.
-		// We don't block here - MemberPress will handle blocking if needed
-		apply_filters( 'authenticate', null, $log, $pwd );
+		// Trigger authenticate filter to track credentials and check lockouts.
+		$auth_result = apply_filters( 'authenticate', null, $log, $pwd );
 
-		// Return errors unchanged - we're only tracking, not blocking
+		if ( is_wp_error( $auth_result ) ) {
+			$codes = $auth_result->get_error_codes();
+			if ( in_array( 'too_many_retries', $codes, true ) ) {
+				return array( $auth_result->get_error_message( 'too_many_retries' ) );
+			}
+			if ( in_array( 'username_blacklisted', $codes, true ) ) {
+				return array( $auth_result->get_error_message( 'username_blacklisted' ) );
+			}
+		}
+
+		if ( ! $this->is_limit_login_ok() ) {
+			return array( $this->error_msg() );
+		}
+
 		return $errors;
 	}
 
@@ -2261,10 +2278,12 @@ class LimitLoginAttempts
 				$time_left = ( ! empty( $response['time_left'] ) ) ? $response['time_left'] : 0;
 
 				// @temporary WP 7.0 compat — mirror cloud deny in local lockouts so is_limit_login_ok() blocks consistently.
+				// TODO: Remove after WP 7.1 release or when auth flow is stable.
 				if ( $time_left > 0 ) {
-					$lockouts       = Config::get( 'lockouts' );
-					$lockouts       = is_array( $lockouts ) ? $lockouts : array();
-					$lockouts[ $ip ] = time() + ( (int) $time_left * MINUTE_IN_SECONDS );
+					$lockouts        = Config::get( 'lockouts' );
+					$lockouts        = is_array( $lockouts ) ? $lockouts : array();
+					$cloud_until     = time() + ( (int) $time_left * MINUTE_IN_SECONDS );
+					$lockouts[ $ip ] = max( isset( $lockouts[ $ip ] ) ? $lockouts[ $ip ] : 0, $cloud_until );
 					Config::update( 'lockouts', $lockouts );
 				}
 
@@ -2411,6 +2430,7 @@ class LimitLoginAttempts
 	 */
 	public function limit_login_failed( $username ) {
 		// @temporary WP 7.0 compat — prevent double-recording when late authenticate fallback already fired.
+		// TODO: Remove after WP 7.1 release or when auth flow is stable.
 		if ( self::$failed_login_recorded_in_request ) {
 			return;
 		}

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -1608,13 +1608,13 @@ class LimitLoginAttempts
 		if (
 			! $this->is_ip_whitelisted( $ip )
 			&& ! $this->is_username_whitelisted( $username )
-			&& ! $this->is_limit_login_ok()
+			&& ! $this->is_limit_login_ok( $username )
 		) {
 			global $limit_login_my_error_shown;
 			$limit_login_my_error_shown = true;
 
 			$error = new WP_Error();
-			$error->add( 'too_many_retries', $this->error_msg() );
+			$error->add( 'too_many_retries', $this->error_msg( $username ) );
 			LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
 
 			return $error;
@@ -2013,11 +2013,60 @@ class LimitLoginAttempts
 
 
 	/**
+	 * Resolve login identifier for cloud ACL checks.
+	 *
+	 * @param string $username Optional username from the auth hook.
+	 * @return string
+	 */
+	private function resolve_login_username( $username = '' ) {
+		if ( '' !== $username ) {
+			return $username;
+		}
+
+		if ( isset( $_REQUEST['log'] ) ) {
+			return sanitize_text_field( wp_unslash( $_REQUEST['log'] ) );
+		}
+
+		if ( $this->integration_manager ) {
+			return $this->integration_manager->get_login_identifier();
+		}
+
+		return '';
+	}
+
+	/**
+	 * Cloud ACL lockout state for the current request (null when not in cloud mode).
+	 *
+	 * @param string $username Optional username from the auth hook.
+	 * @return bool|null True when login is allowed, false when denied, null when local mode applies.
+	 * @throws Exception
+	 */
+	private function is_cloud_login_allowed( $username = '' ) {
+		if ( ! self::$cloud_app ) {
+			return null;
+		}
+
+		$username = $this->resolve_login_username( $username );
+		if ( '' === $username ) {
+			return true;
+		}
+
+		$response = $this->get_auth_acl_response( $username );
+		if ( ! $response ) {
+			return true;
+		}
+
+		return ( 'deny' !== $response['result'] );
+	}
+
+	/**
 	 * Check if it is ok to login
 	 *
+	 * @param string $username Optional username from the auth hook.
 	 * @return bool
+	 * @throws Exception
 	 */
-	public function is_limit_login_ok()
+	public function is_limit_login_ok( $username = '' )
 	{
 		$ip = $this->get_address();
 
@@ -2026,7 +2075,12 @@ class LimitLoginAttempts
 			return true;
 		}
 
-		/* lockout active? */
+		$cloud_allowed = $this->is_cloud_login_allowed( $username );
+		if ( null !== $cloud_allowed ) {
+			return $cloud_allowed;
+		}
+
+		/* lockout active? (local mode only) */
 		$lockouts = Config::get( Config::OPTION_LOCKOUTS );
 
 		return ( ! is_array( $lockouts ) || ! isset( $lockouts[ $ip ] ) || time() >= $lockouts[ $ip ] );
@@ -2095,8 +2149,8 @@ class LimitLoginAttempts
 			}
 		}
 
-		if ( ! $this->is_limit_login_ok() ) {
-			return array( $this->error_msg() );
+		if ( ! $this->is_limit_login_ok( $log ) ) {
+			return array( $this->error_msg( $log ) );
 		}
 
 		return $errors;
@@ -2256,8 +2310,6 @@ class LimitLoginAttempts
 		LoginFlowTransientStore::ensure_token();
 		LoginFlowTransientStore::merge( array( 'login_attempts_left' => 0 ) );
 
-		$ip = $this->get_address();
-
 		if ( self::$cloud_app && $response = self::$cloud_app->lockout_check( array(
 				'ip'        => Helpers::get_all_ips(),
 				'login'     => $username,
@@ -2276,16 +2328,6 @@ class LimitLoginAttempts
 				$err = __( '<strong>ERROR</strong>: Too many failed login attempts.', 'limit-login-attempts-reloaded' );
 
 				$time_left = ( ! empty( $response['time_left'] ) ) ? $response['time_left'] : 0;
-
-				// @temporary WP 7.0 compat — mirror cloud deny in local lockouts so is_limit_login_ok() blocks consistently.
-				// TODO: Remove after WP 7.1 release or when auth flow is stable.
-				if ( $time_left > 0 ) {
-					$lockouts        = Config::get( 'lockouts' );
-					$lockouts        = is_array( $lockouts ) ? $lockouts : array();
-					$cloud_until     = time() + ( (int) $time_left * MINUTE_IN_SECONDS );
-					$lockouts[ $ip ] = max( isset( $lockouts[ $ip ] ) ? $lockouts[ $ip ] : 0, $cloud_until );
-					Config::update( 'lockouts', $lockouts );
-				}
 
 				if ( $time_left > 60 ) {
 
@@ -2709,7 +2751,7 @@ class LimitLoginAttempts
 		}
 		$ip       = $this->get_address();
 		$user_login = is_a( $user, 'WP_User' ) ? $user->user_login : ( ( ! empty( $user ) && ! is_wp_error( $user ) ) ? $user : '' );
-		$not_locked_out = $this->check_whitelist_ips( false, $ip ) || $this->check_whitelist_usernames( false, $user_login ) || $this->is_limit_login_ok();
+		$not_locked_out = $this->check_whitelist_ips( false, $ip ) || $this->check_whitelist_usernames( false, $user_login ) || $this->is_limit_login_ok( $username );
 
 		if ( is_wp_error( $user ) ) {
 			return $user;
@@ -2726,7 +2768,7 @@ class LimitLoginAttempts
 			$error = new WP_Error();
 			global $limit_login_my_error_shown;
 			$limit_login_my_error_shown = true;
-			$error->add( 'too_many_retries', $this->error_msg() );
+			$error->add( 'too_many_retries', $this->error_msg( $username ) );
 			LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
 			return $error;
 		}
@@ -2750,7 +2792,7 @@ class LimitLoginAttempts
 		if (
 			$this->check_whitelist_ips( false, $ip )
 			|| $this->check_whitelist_usernames( false, $user_login )
-			|| $this->is_limit_login_ok()
+			|| $this->is_limit_login_ok( $username )
 		) {
 			return $user;
 		}
@@ -2770,7 +2812,7 @@ class LimitLoginAttempts
 		} else {
 
 			// This error should be the same as in "shake it" filter below
-			$error->add( 'too_many_retries', $this->error_msg() );
+			$error->add( 'too_many_retries', $this->error_msg( $username ) );
 		}
 
 		LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
@@ -2812,10 +2854,42 @@ class LimitLoginAttempts
 	/**
 	 * Construct informative error message
 	 *
+	 * @param string $username Optional username from the auth hook.
 	 * @return string
+	 * @throws Exception
 	 */
-	public function error_msg()
+	public function error_msg( $username = '' )
 	{
+		if ( self::$cloud_app ) {
+			$app_errors = self::$cloud_app->get_errors();
+			if ( ! empty( $app_errors ) ) {
+				$msg = is_array( $app_errors ) ? implode( ' ', $app_errors ) : (string) $app_errors;
+				$this->all_errors_array['late_hook_errors'] = $msg;
+				LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
+
+				return $msg;
+			}
+
+			$username = $this->resolve_login_username( $username );
+			if ( '' !== $username ) {
+				$response = $this->get_auth_acl_response( $username );
+				if ( $response && 'deny' === $response['result'] ) {
+					$time_left = ! empty( $response['time_left'] ) ? (int) $response['time_left'] : 0;
+					$msg       = wp_strip_all_tags( $this->build_lockout_error_message( $time_left ) );
+					$this->all_errors_array['late_hook_errors'] = $msg;
+					LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
+
+					return $msg;
+				}
+			}
+
+			$msg = __( '<strong>ERROR</strong>: Too many failed login attempts.', 'limit-login-attempts-reloaded' ) . ' ' . __( 'Please try again later.', 'limit-login-attempts-reloaded' );
+			$this->all_errors_array['late_hook_errors'] = $msg;
+			LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
+
+			return $msg;
+		}
+
 		$ip       = $this->get_address();
 		$lockouts = Config::get( Config::OPTION_LOCKOUTS );
 		$a        = $this->checkKey($lockouts, $ip);

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -750,11 +750,8 @@ class LimitLoginAttempts
 			Config::update( 'auto_update_choice', 0 );
 		}
 
-		// Load languages files via a later hook
-		// TODO: load_plugin_textdomain() is deprecated in WordPress 6.9+. WordPress now uses automatic JIT (Just-In-Time) translation loading.
-		// This function still works for backward compatibility, but should be removed in future versions.
-		// JIT translation loading automatically loads translation files when needed, so explicit load_plugin_textdomain() calls are no longer necessary.
-	    add_action('init', array( $this, 'load_plugin_textdomain_in_time' ) );
+		// Load translations and defaults in a WP-version-safe way.
+		add_action( 'init', array( $this, 'load_plugin_textdomain_in_time' ) );
 
 		$this->register_mfa_providers();
 
@@ -829,18 +826,19 @@ class LimitLoginAttempts
 
 
 	/**
-	 * Later loading of translations load_plugin_textdomain
-	 * 
-	 * TODO: This method uses deprecated load_plugin_textdomain() function.
-	 * WordPress 6.9+ uses automatic JIT (Just-In-Time) translation loading, which means
-	 * translation files are loaded automatically when needed. This explicit call can be
-	 * removed in future versions. Ensure translation files are properly named and placed
-	 * in the languages directory for JIT loading to work correctly.
+	 * Initialize i18n and plugin defaults.
+	 *
+	 * WordPress 6.9+ (including 7.x) uses JIT translation loading and no longer needs
+	 * explicit `load_plugin_textdomain()` calls. Older WordPress versions still rely on it.
+	 *
+	 * @return void
 	 */
 	public function load_plugin_textdomain_in_time()
 	{
-		// TODO: Remove load_plugin_textdomain() call - WordPress 6.9+ handles translations automatically via JIT loading
-		load_plugin_textdomain( 'limit-login-attempts-reloaded', false, plugin_basename( __DIR__ ) . '/../languages' );
+		if ( version_compare( Helpers::get_wordpress_version(), '6.9', '<' ) && function_exists( 'load_plugin_textdomain' ) ) {
+			load_plugin_textdomain( 'limit-login-attempts-reloaded', false, plugin_basename( __DIR__ ) . '/../languages' );
+		}
+
 		Config::init_defaults();
 	}
 

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -2035,10 +2035,14 @@ class LimitLoginAttempts
 	}
 
 	/**
-	 * Cloud ACL lockout state for the current request (null when not in cloud mode).
+	 * Cloud ACL lockout state for the current request.
+	 *
+	 * Returns null when cloud mode is off, the username cannot be resolved, or
+	 * the Cloud API is unreachable — in those cases the caller must fall back
+	 * to the local lockouts check so failover keeps blocking attackers.
 	 *
 	 * @param string $username Optional username from the auth hook.
-	 * @return bool|null True when login is allowed, false when denied, null when local mode applies.
+	 * @return bool|null True when login is allowed, false when denied, null when local check applies.
 	 * @throws Exception
 	 */
 	private function is_cloud_login_allowed( $username = '' ) {
@@ -2048,12 +2052,12 @@ class LimitLoginAttempts
 
 		$username = $this->resolve_login_username( $username );
 		if ( '' === $username ) {
-			return true;
+			return null;
 		}
 
 		$response = $this->get_auth_acl_response( $username );
 		if ( ! $response ) {
-			return true;
+			return null;
 		}
 
 		return ( 'deny' !== $response['result'] );
@@ -2870,9 +2874,9 @@ class LimitLoginAttempts
 				return $msg;
 			}
 
-			$username = $this->resolve_login_username( $username );
-			if ( '' !== $username ) {
-				$response = $this->get_auth_acl_response( $username );
+			$resolved_username = $this->resolve_login_username( $username );
+			if ( '' !== $resolved_username ) {
+				$response = $this->get_auth_acl_response( $resolved_username );
 				if ( $response && 'deny' === $response['result'] ) {
 					$time_left = ! empty( $response['time_left'] ) ? (int) $response['time_left'] : 0;
 					$msg       = wp_strip_all_tags( $this->build_lockout_error_message( $time_left ) );
@@ -2882,13 +2886,9 @@ class LimitLoginAttempts
 					return $msg;
 				}
 			}
-
-			$msg = __( '<strong>ERROR</strong>: Too many failed login attempts.', 'limit-login-attempts-reloaded' ) . ' ' . __( 'Please try again later.', 'limit-login-attempts-reloaded' );
-			$this->all_errors_array['late_hook_errors'] = $msg;
-			LoginFlowTransientStore::merge( array( 'errors_in_early_hook' => false ) );
-
-			return $msg;
 		}
+
+		// Cloud is off or unreachable — fall back to the local lockouts timer so failover messages match the lockout state.
 
 		$ip       = $this->get_address();
 		$lockouts = Config::get( Config::OPTION_LOCKOUTS );

--- a/core/integrations/BaseIntegration.php
+++ b/core/integrations/BaseIntegration.php
@@ -81,7 +81,7 @@ abstract class BaseIntegration implements IntegrationInterface {
 	 * @return string
 	 */
 	protected function get_error_message() {
-		return $this->llar_instance->error_msg();
+		return $this->llar_instance->error_msg( $this->get_login_identifier() );
 	}
 
 	/**
@@ -90,7 +90,7 @@ abstract class BaseIntegration implements IntegrationInterface {
 	 * @return bool
 	 */
 	protected function is_login_allowed() {
-		return $this->llar_instance->is_limit_login_ok();
+		return $this->llar_instance->is_limit_login_ok( $this->get_login_identifier() );
 	}
 
 	/**

--- a/core/integrations/MemberPressIntegration.php
+++ b/core/integrations/MemberPressIntegration.php
@@ -268,8 +268,8 @@ class MemberPressIntegration extends BaseIntegration {
 
 		// Wrong-password path usually leaves authenticate() as incorrect_password only: core does not
 		// call wp_authenticate_user (where too_many_retries is added after a valid password check), and
-		// authenticate_late_lockout_check runs only on WP 7.0+. Lockout is still stored in lockouts[];
-		// is_login_allowed() mirrors that — surface the message whenever the IP is locked.
+		// authenticate_late_lockout_check runs only on WP 7.0+. is_login_allowed() uses cloud ACL
+		// (or local lockouts when cloud is off) to surface the lockout message on this path.
 		if ( ! $this->is_login_allowed() ) {
 			return array( $this->get_error_message() );
 		}

--- a/core/integrations/MemberPressIntegration.php
+++ b/core/integrations/MemberPressIntegration.php
@@ -235,9 +235,9 @@ class MemberPressIntegration extends BaseIntegration {
 	 * to track credentials and check lockouts before MemberPress validates the password
 	 * This enables the plugin to display remaining attempts messages
 	 *
-	 * @param array $errors Array of existing errors
+	 * @param array $errors Array of existing errors (from MemberPress validate_login, applied before this filter).
 	 * @param array $params Login parameters (log, pwd)
-	 * @return array Unchanged errors array (we don't block, only track)
+	 * @return array Errors for MemberPress; when LLAR blocks login, returns that message so MP shows it (MP uses only $errors[0]).
 	 */
 	public function mepr_validate_login_handler( $errors, $params = array() ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- MemberPress handles nonce verification
@@ -250,13 +250,30 @@ class MemberPressIntegration extends BaseIntegration {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- MemberPress handles nonce verification
 		$pwd = isset( $_POST['pwd'] ) ? wp_unslash( $_POST['pwd'] ) : ''; // Password should not be sanitized, but needs wp_unslash() to remove magic quotes
 
-		// Trigger authenticate filter to track credentials and check lockouts
-		// This sets $limit_login_nonempty_credentials and $_SESSION['login_attempts_left']
-		// We don't block here - MemberPress will handle blocking if needed
-		// Note: Result is intentionally ignored - we only need side effects (setting global variables)
-		apply_filters( 'authenticate', null, $log, $pwd );
+		// Trigger authenticate filter to track credentials and check lockouts.
+		// MemberPress runs validate_login before this filter, so $errors may already contain a generic
+		// "incorrect password" message; MeprLoginCtrl only displays $errors[0]. If authenticate returns
+		// lockout/blacklist, we must replace $errors so the user sees LLAR messaging.
+		$auth_result = apply_filters( 'authenticate', null, $log, $pwd );
 
-		// Return errors unchanged - we're only tracking, not blocking
+		if ( is_wp_error( $auth_result ) ) {
+			$codes = $auth_result->get_error_codes();
+			if ( in_array( 'too_many_retries', $codes, true ) ) {
+				return array( $auth_result->get_error_message( 'too_many_retries' ) );
+			}
+			if ( in_array( 'username_blacklisted', $codes, true ) ) {
+				return array( $auth_result->get_error_message( 'username_blacklisted' ) );
+			}
+		}
+
+		// Wrong-password path usually leaves authenticate() as incorrect_password only: core does not
+		// call wp_authenticate_user (where too_many_retries is added after a valid password check), and
+		// authenticate_late_lockout_check runs only on WP 7.0+. Lockout is still stored in lockouts[];
+		// is_login_allowed() mirrors that — surface the message whenever the IP is locked.
+		if ( ! $this->is_login_allowed() ) {
+			return array( $this->get_error_message() );
+		}
+
 		return $errors;
 	}
 }


### PR DESCRIPTION
## Summary

- Add late `authenticate` safety net (priority 99990) for WP 7.0+ where `wp_login_failed` is no longer a reliable signal for failed logins due to changed auth flow and hook execution order.
- On WP 7.0+ keep `wp_login_failed` and `wp_authenticate_user` hooks active in cloud ACL=pass branch (on older WP original removal logic preserved).
- Mirror cloud lockout `deny` into local lockouts table so `is_limit_login_ok()` blocks consistently.
- Add per-request guard (`$failed_login_recorded_in_request`) to prevent double-counting across multiple recording paths.
- Extract shared `$auth_failure_codes` into static property; add cached `is_wp_at_least()` helper.
- Skip `load_plugin_textdomain()` on WP 6.9+ (JIT translations); use `LLA_PLUGIN_DIR` for languages path.
- All WP 7.0 changes gated behind `is_wp_at_least('7.0')` and marked `@temporary`.