### PR TITLE
feat: rebrand Micro Cloud as 14 day free trial across admin UI

### DIFF
--- a/assets/css/limit-login-attempts.css
+++ b/assets/css/limit-login-attempts.css
@@ -574,16 +574,6 @@ button.llar_button:focus, #llar-setting-page button.button:focus, .llar_button:f
 .limit-login-page-settings .llar-test-email-notification-loader .msg.success {
   color: #71c21b;
 }
-.limit-login-page-settings .llar-protect-notice {
-  font-size: 15px;
-  color: #848484;
-  margin-left: 10px;
-}
-.limit-login-page-settings .llar-protect-notice a {
-  color: #222222;
-  text-decoration: none;
-  border-bottom: 1px dashed;
-}
 .limit-login-page-settings .llar-toggle-setup-field {
   color: #2271b1;
   text-decoration-style: dashed;
@@ -809,7 +799,7 @@ button.llar_button:focus, #llar-setting-page button.button:focus, .llar_button:f
 #llar-setting-page .llar-settings-wrap .llar-form-table tr td a.unlink:hover, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td a.unlink:hover, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td a.unlink:hover, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td a.unlink:hover, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td a.unlink:hover, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td a.unlink:hover {
   border-bottom: unset;
 }
-#llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .llar-protect-notice {
+#llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-secondary {
   font-size: 16px;
   line-height: inherit;
   color: #A4A8B7;
@@ -817,23 +807,12 @@ button.llar_button:focus, #llar-setting-page button.button:focus, .llar_button:f
   max-width: 740px;
 }
 @media screen and (max-width: 1599.5px) {
-  #llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .llar-protect-notice {
+  #llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-additional, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-secondary {
     font-size: 14px;
   }
 }
-#llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .llar-protect-notice {
+#llar-setting-page .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .description-secondary, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .description-secondary {
   color: #666D84;
-}
-#llar-setting-page .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .llar-protect-notice, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .llar-protect-notice {
-  font-size: inherit;
-  color: inherit;
-}
-#llar-setting-page .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a {
-  text-decoration: none;
-  border-bottom: unset;
-}
-#llar-setting-page .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a:hover, #llar-setting-page-logs .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a:hover, #llar-setting-page-logs__active .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a:hover, #llar-setting-page-debug .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a:hover, #llar-setting-page-premium .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a:hover, #llar-setting-page-help .llar-settings-wrap .llar-form-table tr td .llar-protect-notice a:hover {
-  border-bottom: 1px solid currentColor;
 }
 #llar-setting-page .add_block__under_table, #llar-setting-page-logs .add_block__under_table, #llar-setting-page-logs__active .add_block__under_table, #llar-setting-page-debug .add_block__under_table, #llar-setting-page-premium .add_block__under_table, #llar-setting-page-help .add_block__under_table {
   margin: 8px 0;
@@ -2723,6 +2702,9 @@ button.llar_button:focus, #llar-setting-page button.button:focus, .llar_button:f
   display: flex;
   flex-direction: row;
   column-gap: 16px;
+}
+#llar-dashboard-page .dashboard-section-1 .info-box-3 .actions__buttons--centered {
+  justify-content: center;
 }
 #llar-dashboard-page .dashboard-section-1 .info-box-3 .actions__buttons a {
   text-transform: uppercase;

--- a/assets/sass/_dashboard-page.scss
+++ b/assets/sass/_dashboard-page.scss
@@ -302,6 +302,10 @@
           flex-direction: row;
           column-gap: 16px;
 
+          &--centered {
+            justify-content: center;
+          }
+
           a {
             text-transform: uppercase;
             font-size: 16px;

--- a/assets/sass/limit-login-attempts.scss
+++ b/assets/sass/limit-login-attempts.scss
@@ -209,18 +209,6 @@
     }
   }
 
-  .llar-protect-notice {
-    font-size: 15px;
-    color: #848484;
-    margin-left: 10px;
-
-    a {
-      color: #222222;
-      text-decoration: none;
-      border-bottom: 1px dashed;
-    }
-  }
-
   .llar-toggle-setup-field {
     color: #2271b1;
     text-decoration-style: dashed;
@@ -474,7 +462,7 @@
             }
           }
 
-          .description-additional, .description-secondary, .llar-protect-notice {
+          .description-additional, .description-secondary {
             font-size: 16px;
             line-height: inherit;
             color: $typography-additional;
@@ -486,22 +474,8 @@
             }
           }
 
-          .description-secondary, .llar-protect-notice {
+          .description-secondary {
             color: $typography-secondary;
-          }
-
-          .llar-protect-notice {
-            font-size: inherit;
-            color: inherit;
-
-            a {
-              text-decoration: none;
-              border-bottom: unset;
-
-              &:hover {
-                border-bottom: 1px solid currentColor;
-              }
-            }
           }
         }
       }

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -460,7 +460,7 @@ class LimitLoginAttempts
 	private function get_micro_cloud_recommendation_html() {
 		return sprintf(
 			__(
-				'Based on your level of brute force activity, we recommend <a class="llar_orange %s">free Micro Cloud upgrade</a> to access features to reduce failed logins and improve site performance.',
+				'Based on your level of brute force activity, we recommend <a class="llar_orange %s">starting a free 14 day trial</a> to access features to reduce failed logins and improve site performance.',
 				'limit-login-attempts-reloaded'
 			),
 			'button_micro_cloud'

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -1061,7 +1061,7 @@ class LimitLoginAttempts
 				$slug = $this->get_options_page_uri('dashboard#modal_micro_cloud');
 
 				$actions = array_merge( array(
-					'<a href="' . esc_html( $slug ) . '" style="font-weight: bold;">' . __( 'Free Upgrade', 'limit-login-attempts-reloaded' ) . '</a>',
+					'<a href="' . esc_html( $slug ) . '" style="font-weight: bold;">' . __( 'Free Trial', 'limit-login-attempts-reloaded' ) . '</a>',
 				), $actions );
 			} else {
 
@@ -1802,7 +1802,7 @@ class LimitLoginAttempts
 		if ( ! $is_cloud_app_enabled ) {
 
 			$slug       = '&tab=dashboard#modal_micro_cloud';
-			$name_item  = $is_local_empty_setup_code ? __( 'Free Upgrade', 'limit-login-attempts-reloaded' ) : __( 'Premium', 'limit-login-attempts-reloaded' );
+			$name_item  = $is_local_empty_setup_code ? __( 'Free Trial', 'limit-login-attempts-reloaded' ) : __( 'Premium', 'limit-login-attempts-reloaded' );
 			$url_item   = $is_local_empty_setup_code ? $slug : '&tab=premium';
 
 			$submenu_items[] = array(

--- a/resources/compare-plans-data.php
+++ b/resources/compare-plans-data.php
@@ -9,38 +9,36 @@
 
 use LLAR\Core\Config;
 
-$min_plan = $active_app === 'custom' ? 'Micro Cloud' : 'Free';
+$min_plan = 'Free';
 
 $plans = $this->array_name_plans();
 $actual_plan = $active_app === 'custom' ? $this->info_sub_group() : $min_plan;
+$compare_actual_plan = ( 'Micro Cloud' === $actual_plan ) ? 'Free' : $actual_plan;
 $upgrade_url = $active_app === 'custom' ? $this->info_upgrade_url() : 'https://www.limitloginattempts.com/info.php?from=plugin-premium-tab-upgrade';
 
 $attribute = [];
 foreach ( $plans as $plan => $rate ) {
+	if ( 'Micro Cloud' === $plan ) {
+		continue;
+	}
 
-    if ( $rate < $plans[$actual_plan] ) {
-        $attribute[$plan]['attr'] = '';
-        $attribute[$plan]['title'] = '';
-    }
-    elseif ( $rate === $plans[$actual_plan] ) {
-	    $attribute[$plan]['attr'] = 'class="button menu__item button__transparent_orange llar-disabled"';
-	    $attribute[$plan]['title'] = __( 'Installed', 'limit-login-attempts-reloaded' );
-    }
-    elseif ( $plan === 'Micro Cloud' ) {
-        $attribute[$plan]['attr'] = 'class="button menu__item button__orange button_micro_cloud"';
-        $attribute[$plan]['title'] = __( 'Get Started (Free)', 'limit-login-attempts-reloaded' );
-    }
-    else {
+    if ( $rate < $plans[ $compare_actual_plan ] ) {
+        $attribute[ $plan ]['attr'] = '';
+        $attribute[ $plan ]['title'] = '';
+    } elseif ( $rate === $plans[ $compare_actual_plan ] ) {
+	    $attribute[ $plan ]['attr'] = 'class="button menu__item button__transparent_orange llar-disabled"';
+	    $attribute[ $plan ]['title'] = __( 'Installed', 'limit-login-attempts-reloaded' );
+    } else {
 		if ( $plan === 'Premium' ) {
-			$attribute[$plan]['attr'] = 'class="button menu__item button__orange" href="' . esc_url(( $min_plan === 'Micro Cloud' )	? add_query_arg('id', '9', $this->info_upgrade_url())	: "https://www.limitloginattempts.com/info.php?id=24") . '" target="_blank"';
+			$attribute[ $plan ]['attr'] = 'class="button menu__item button__orange" href="' . esc_url( ( $active_app === 'custom' ) ? add_query_arg( 'id', '9', $this->info_upgrade_url() ) : 'https://www.limitloginattempts.com/info.php?id=24' ) . '" target="_blank"';
 		}
 		if ( $plan === 'Premium +' ) {
-			$attribute[$plan]['attr'] = 'class="button menu__item button__orange" href="' . esc_url(( $min_plan === 'Micro Cloud' )	? add_query_arg('id', '10', $this->info_upgrade_url())	: "https://www.limitloginattempts.com/info.php?id=25") . '" target="_blank"';
+			$attribute[ $plan ]['attr'] = 'class="button menu__item button__orange" href="' . esc_url( ( $active_app === 'custom' ) ? add_query_arg( 'id', '10', $this->info_upgrade_url() ) : 'https://www.limitloginattempts.com/info.php?id=25' ) . '" target="_blank"';
 		}
 		if ( $plan === 'Professional' ) {
-			$attribute[$plan]['attr'] = 'class="button menu__item button__orange" href="' . esc_url(( $min_plan === 'Micro Cloud' )	? add_query_arg('id', '11', $this->info_upgrade_url())	: "https://www.limitloginattempts.com/info.php?id=26") . '" target="_blank"';
+			$attribute[ $plan ]['attr'] = 'class="button menu__item button__orange" href="' . esc_url( ( $active_app === 'custom' ) ? add_query_arg( 'id', '11', $this->info_upgrade_url() ) : 'https://www.limitloginattempts.com/info.php?id=26' ) . '" target="_blank"';
 		}
-        $attribute[$plan]['title'] = __( 'Upgrade now', 'limit-login-attempts-reloaded' );
+        $attribute[ $plan ]['title'] = __( '14 Day Trial', 'limit-login-attempts-reloaded' );
     }
 }
 
@@ -50,21 +48,18 @@ $yes = '<span class="llar_orange">&#x2713;</span>';
 $compare_list = array(
 	'buttons_header'                                => array(
 		'Free'          => '<a ' . $attribute['Free']['attr'] . '>' . esc_html__( $attribute['Free']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
-		'Micro Cloud'   => '<a ' . $attribute['Micro Cloud']['attr'] . '>' . esc_html__( $attribute['Micro Cloud']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 		'Premium'       => '<a ' . $attribute['Premium']['attr'] . '>' . esc_html__( $attribute['Premium']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 		'Premium +'     => '<a ' . $attribute['Premium +']['attr'] . '>' . esc_html__( $attribute['Premium +']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 		'Professional'  => '<a ' . $attribute['Professional']['attr'] . '>' . esc_html__( $attribute['Professional']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 	),
     __( 'Limit Number of Retry Attempts', 'limit-login-attempts-reloaded' )                => array(
         'Free'          => $yes,
-        'Micro Cloud'   => $yes,
         'Premium'       => $yes,
         'Premium +'     => $yes,
         'Professional'  => $yes,
     ),
     __( 'Configurable Lockout Timing', 'limit-login-attempts-reloaded' )                   => array(
         'Free'          => $yes,
-        'Micro Cloud'   => $yes,
         'Premium'       => $yes,
         'Premium +'     => $yes,
         'Professional'  => $yes,
@@ -72,7 +67,6 @@ $compare_list = array(
     __( 'Login Firewall', 'limit-login-attempts-reloaded' )                                => array(
         'description'   =>  __( "Secure your login page with our cutting-edge login firewall, defending against unauthorized access attempts and protecting your users' accounts and sensitive information.", 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes,
         'Premium'       => $yes,
         'Premium +'     => $yes,
         'Professional'  => $yes,
@@ -80,7 +74,6 @@ $compare_list = array(
     __( 'Performance Optimizer', 'limit-login-attempts-reloaded' )                         => array(
         'description'   =>  __( 'Absorb failed login attempts from brute force bots in the cloud to keep your website at its optimal performance.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes . '<span class="description">' . sprintf(esc_html__( '1k for first month%s(100 per month after)', 'limit-login-attempts-reloaded' ),'<br>') . '</span>',
         'Premium'       => $yes . '<span class="description">' . esc_html__( '100k requests per month', 'limit-login-attempts-reloaded' ) . '</span>',
         'Premium +'     => $yes . '<span class="description">' . esc_html__( '200k requests per month', 'limit-login-attempts-reloaded' ) . '</span>',
         'Professional'  => $yes . '<span class="description">' . esc_html__( '300k requests per month', 'limit-login-attempts-reloaded' ) . '</span>',
@@ -88,7 +81,6 @@ $compare_list = array(
 	__( 'Successful Login Logs', 'limit-login-attempts-reloaded' )                         => array(
 		'description'   =>  __( 'Ensure the security and integrity of your website by logging your successful logins.', 'limit-login-attempts-reloaded' ),
 		'Free'          => $lock,
-		'Micro Cloud'   => $yes,
 		'Premium'       => $yes,
 		'Premium +'     => $yes,
 		'Professional'  => $yes,
@@ -96,7 +88,6 @@ $compare_list = array(
     __( 'Block By Country', 'limit-login-attempts-reloaded' )                              => array(
         'description'   =>  __( 'Disable IPs from any region to disable logins.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes,
         'Premium'       => $lock,
         'Premium +'     => $yes,
         'Professional'  => $yes,
@@ -104,7 +95,6 @@ $compare_list = array(
     __( 'Access Blocklist of Malicious IPs', 'limit-login-attempts-reloaded' )             => array(
         'description'   =>  __( 'Add another layer of protection from brute force bots by accessing a global database of known IPs with malicious activity.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes,
         'Premium'       => $lock,
         'Premium +'     => $yes,
         'Professional'  => $yes,
@@ -112,7 +102,6 @@ $compare_list = array(
     __( 'Auto IP Blocklist', 'limit-login-attempts-reloaded' )                             => array(
         'description'   =>  __( 'Automatically add malicious IPs to your blocklist when triggered by the system.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes,
         'Premium'       => $lock,
         'Premium +'     => $lock,
         'Professional'  => $yes,
@@ -120,7 +109,6 @@ $compare_list = array(
     __( 'Access Active Cloud Blocklist', 'limit-login-attempts-reloaded' )                 => array(
         'description'   =>  __( 'Use system wide data from over 10,000 WordPress websites to identify and block malicious IPs. This is an active list in real-time.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes,
         'Premium'       => $lock,
         'Premium +'     => $lock,
         'Professional'  => $yes,
@@ -128,7 +116,6 @@ $compare_list = array(
     __( 'Intelligent IP Blocking', 'limit-login-attempts-reloaded' )                       => array(
         'description'   =>  __( 'Use active IP database via the cloud to automatically block users before they are able to make a failed login.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $yes,
         'Premium'       => $yes,
         'Premium +'     => $yes,
         'Professional'  => $yes,
@@ -136,7 +123,6 @@ $compare_list = array(
     __( 'Synchronize Lockouts & Safelists/Blocklists', 'limit-login-attempts-reloaded' )   => array(
         'description'   =>  __( 'Lockouts & safelists/blocklists can be shared between multiple domains to enhance protection.', 'limit-login-attempts-reloaded' ),
         'Free'          => $lock,
-        'Micro Cloud'   => $lock,
         'Premium'       => $yes,
         'Premium +'     => $yes,
         'Professional'  => $yes,
@@ -146,14 +132,12 @@ $compare_list = array(
         	__( 'Receive 1 on 1 technical support via email for any issues. Free support availabe in the <a href="%s" target="_blank">WordPress support forum</a>.', 'limit-login-attempts-reloaded' ),
 	        'https://wordpress.org/support/plugin/limit-login-attempts-reloaded/'),
         'Free'          => $lock,
-        'Micro Cloud'   => $lock,
         'Premium'       => $yes,
         'Premium +'     => $yes,
         'Professional'  => $yes,
     ),
     'buttons_footer'                                => array(
 	    'Free'          => '<a ' . $attribute['Free']['attr'] . '>' . esc_html__( $attribute['Free']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
-	    'Micro Cloud'   => '<a ' . $attribute['Micro Cloud']['attr'] . '>' . esc_html__( $attribute['Micro Cloud']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 	    'Premium'       => '<a ' . $attribute['Premium']['attr'] . '>' . esc_html__( $attribute['Premium']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 	    'Premium +'     => '<a ' . $attribute['Premium +']['attr'] . '>' . esc_html__( $attribute['Premium +']['title'], 'limit-login-attempts-reloaded' ) . '</a>',
 	    'Professional'  => '<a ' . $attribute['Professional']['attr'] . '>' . esc_html__( $attribute['Professional']['title'], 'limit-login-attempts-reloaded' ) . '</a>',

--- a/views/app-widgets/login-attempts.php
+++ b/views/app-widgets/login-attempts.php
@@ -87,15 +87,13 @@ $limit = 10;
 	            <?php _e('All logs are stored in the cloud to ensure malicious users are unable to delete or manipulate site login data.', 'limit-login-attempts-reloaded'); ?>
             </div>
             <div class="footer">
-	            <?php if ( ! empty ( $setup_code ) ) :
-		            $text_no_custom = __( 'This feature is only available for<br><a class="link__style_unlink llar_turquoise" href="%s">Premium</a> users.', 'limit-login-attempts-reloaded' );
-	            else:
-		            $text_no_custom = __( 'This feature is only available for<br><a class="link__style_unlink llar_turquoise" href="%s">Premium</a> and <a class="link__style_unlink llar_turquoise button_micro_cloud">Micro Cloud (FREE!)</a> users.', 'limit-login-attempts-reloaded' );
-	            endif ?>
-	            <?php echo sprintf(
+	            <?php
+	            $text_no_custom = __( 'This feature is only available for<br><a class="link__style_unlink llar_turquoise" href="%s">Premium</a> users.', 'limit-login-attempts-reloaded' );
+	            echo sprintf(
 		            $text_no_custom,
 		            '/wp-admin/admin.php?page=limit-login-attempts&tab=premium'
-	            ); ?>
+	            );
+	            ?>
             </div>
         </div>
     </div>

--- a/views/chart-circle-failed-attempts-today.php
+++ b/views/chart-circle-failed-attempts-today.php
@@ -44,9 +44,17 @@ $retries_count       = isset( $chart_circle_data['retries_count'] ) ? (int) $cha
         <span class="llar-label__url">
         </span>
 	<?php endif; ?>
-	<?php echo ( $is_active_app_custom && ! $is_exhausted )
-		? '<span class="llar-premium-label"><span class="dashicons dashicons-saved"></span>' . __( 'Cloud protection enabled', 'limit-login-attempts-reloaded' ) . '</span>'
-		: ''; ?>
+	<?php
+	$premium_label = '';
+	if ( $is_active_app_custom && ! $is_exhausted ) {
+		$premium_label = ( 'Micro Cloud' === $block_sub_group )
+			? __( 'Free Trial', 'limit-login-attempts-reloaded' )
+			: __( 'Cloud protection enabled', 'limit-login-attempts-reloaded' );
+	}
+	if ( $premium_label ) {
+		echo '<span class="llar-premium-label"><span class="dashicons dashicons-saved"></span>' . esc_html( $premium_label ) . '</span>';
+	}
+	?>
 </div>
 <div class="section-content">
     <div class="chart">

--- a/views/emails/failed-login-content.php
+++ b/views/emails/failed-login-content.php
@@ -38,7 +38,7 @@ $admin_name = isset( $admin_name ) && is_string( $admin_name ) ? $admin_name : '
 </p>
 <p style="margin:0 0 12px;font-size:14px;line-height:1.5;color:#333333;">
 	<?php esc_html_e( 'Experiencing frequent attacks or degraded performance?', 'limit-login-attempts-reloaded' ); ?>
-	<a href="{premium_url}" target="_blank" rel="noopener"><?php esc_html_e( 'Try Micro Cloud.', 'limit-login-attempts-reloaded' ); ?></a>
+	<a href="{premium_url}" target="_blank" rel="noopener"><?php esc_html_e( 'Start your 14 day free trial.', 'limit-login-attempts-reloaded' ); ?></a>
 </p>
 <?php include LLA_PLUGIN_DIR . 'views/emails/failed-login-faq.php'; ?>
 <?php if ( Helpers::is_mu() ) : ?>

--- a/views/micro-cloud-modal.php
+++ b/views/micro-cloud-modal.php
@@ -23,7 +23,7 @@ ob_start(); ?>
             <div class="micro_cloud_modal__body_header">
                 <div class="left_side">
                     <div class="title">
-                        <?php _e( 'Start Your 14 Day Free Trial', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( 'Start your 14 day free trial', 'limit-login-attempts-reloaded' ); ?>
                     </div>
                     <div class="description">
                         <?php _e( 'Unlock full access to our premium features including our login firewall, IP Intelligence, and performance optimizer. No credit card required.', 'limit-login-attempts-reloaded' ); ?>

--- a/views/micro-cloud-modal.php
+++ b/views/micro-cloud-modal.php
@@ -23,13 +23,13 @@ ob_start(); ?>
             <div class="micro_cloud_modal__body_header">
                 <div class="left_side">
                     <div class="title">
-                        <?php _e( 'Get Started with Micro Cloud for FREE', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( 'Start Your 14 Day Free Trial', 'limit-login-attempts-reloaded' ); ?>
                     </div>
                     <div class="description">
-                        <?php _e( 'Help us secure our network and we’ll provide you with limited access to our premium features including our login firewall, IP Intelligence, and performance optimizer.', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( 'Unlock full access to our premium features including our login firewall, IP Intelligence, and performance optimizer. No credit card required.', 'limit-login-attempts-reloaded' ); ?>
                     </div>
                     <div class="description-add">
-                        <?php _e( 'Please note that some domains have very high brute force activity, which may cause Micro Cloud to run out of resources in under 24 hours. We will send an email when resources are fully utilized and the app reverts back to the free version. You may upgrade to one of our premium plans to prevent the app from reverting.', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( 'When your 14 day free trial ends, the app automatically reverts to the free version. You may upgrade to one of our premium plans at any time to keep cloud protection.', 'limit-login-attempts-reloaded' ); ?>
                     </div>
                 </div>
                 <div class="right_side">
@@ -40,7 +40,7 @@ ob_start(); ?>
                 <div class="card-header">
                     <div class="title">
                         <img src="<?php echo LLA_PLUGIN_URL ?>assets/css/images/tools.png">
-                        <?php _e( 'How To Activate Micro Cloud', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( 'How To Activate Your Free Trial', 'limit-login-attempts-reloaded' ); ?>
                     </div>
                 </div>
                 <div class="card-body step-first">
@@ -86,7 +86,7 @@ ob_start(); ?>
                         </div>
                         <div class="description_add">
                             <img src="<?php echo LLA_PLUGIN_URL ?>assets/css/images/start.png">
-	                        <?php _e( 'Micro Cloud has been activated!', 'limit-login-attempts-reloaded' ); ?>
+	                        <?php _e( 'Your free trial has been activated!', 'limit-login-attempts-reloaded' ); ?>
                         </div>
                     </div>
                     <div class="button_block-single">

--- a/views/onboarding-popup.php
+++ b/views/onboarding-popup.php
@@ -46,7 +46,7 @@ ob_start(); ?>
         <div class="point__block" data-step="3">
             <div class="point"></div>
             <div class="description">
-				<?php esc_html_e( 'Limited Upgrade', 'limit-login-attempts-reloaded' ); ?>
+				<?php esc_html_e( 'Free Trial', 'limit-login-attempts-reloaded' ); ?>
             </div>
         </div>
         <div class="point__block" data-step="4">
@@ -123,7 +123,7 @@ ob_start(); ?>
 						<?php esc_html_e( 'Yes, show me plan options', 'limit-login-attempts-reloaded' ); ?>
                     </a>
                     <button class="button next_step menu__item button__transparent_orange">
-						<?php esc_html_e( 'No, I don\'t want advanced protection', 'limit-login-attempts-reloaded' ); ?>
+						<?php esc_html_e( 'No thank you, let\'s continue', 'limit-login-attempts-reloaded' ); ?>
                     </button>
                 </div>
             </div>
@@ -177,28 +177,32 @@ ob_start(); ?>
 <div class="llar-onboarding__body">
     <div class="title">
         <img src="<?php echo esc_url( LLA_PLUGIN_URL ); ?>assets/css/images/rocket-min.png">
-		<?php esc_html_e( 'Limited Upgrade (Free)', 'limit-login-attempts-reloaded' ); ?>
+		<?php esc_html_e( 'Unlock Premium FREE for 14 Days', 'limit-login-attempts-reloaded' ); ?>
+    </div>
+    <div class="title_description">
+		<?php esc_html_e( 'No Credit Card Required', 'limit-login-attempts-reloaded' ); ?>
     </div>
     <div class="card mx-auto">
         <div class="field-wrap" id="llar-description-step-3">
             <div class="field-desc-add">
-				<?php 
-				/* translators: %s: line break */
-				printf( esc_html__( 'Help us secure the WordPress network, and in return, we\'ll give you access to Micro Cloud - Our FREE premium plan. %s', 'limit-login-attempts-reloaded' ), '<br />' ); ?>
-                <br>
-				<?php 
-				/* translators: %1$s: opening span tag, %2$s: closing span tag, %3$s: line break */
-				printf( esc_html__( 'You\'ll receive %1$s 1,000 monthly cloud requests %2$s to power advanced login protection tools that block more than 97%% of all attempted logins. %3$s', 'limit-login-attempts-reloaded' ), '<span class="llar_turquoise">', '</span>', '<br />' );
+				<?php
+				echo wp_kses_post(
+					sprintf(
+						__( 'Unlock advanced security features including %1$sCloud Protection, Block by Country, Login Firewall, Successful Login Logs, and much more!%2$s', 'limit-login-attempts-reloaded' ),
+						'<strong>',
+						'</strong>'
+					)
+				);
 				?>
-                <br>
-				<?php 
-				/* translators: %1$s: opening span tag, %2$s: closing span tag, %3$s: line break */
-				printf( esc_html__( '%1$s By proceeding, you agree to participate in our threat-sharing network. %2$s %3$s', 'limit-login-attempts-reloaded' ), '<span class="llar_turquoise">', '</span>', '<br />' );
-				?>
-				<?php esc_html_e( 'You can switch back to the free version of the plugin at any time, which will deactivate Micro Cloud and stop all data sharing.', 'limit-login-attempts-reloaded' ); ?>
+                <br><br>
+				<?php esc_html_e( 'These powerful tools help stop brute force attacks before they happen, protecting your WordPress login from malicious bots and automated attacks.', 'limit-login-attempts-reloaded' ); ?>
+                <br><br>
+				<?php esc_html_e( 'Experience the strongest login protection available for WordPress and see the difference premium security can make.', 'limit-login-attempts-reloaded' ); ?>
+                <br><br>
+				<?php esc_html_e( 'You can return to the free version at any time.', 'limit-login-attempts-reloaded' ); ?>
             </div>
             <div class="field-desc-add">
-				<b><?php esc_html_e( 'Would you like to opt-in?', 'limit-login-attempts-reloaded' ); ?></b>
+				<b><?php esc_html_e( 'Would you like to start your free trial?', 'limit-login-attempts-reloaded' ); ?></b>
             </div>
         </div>
         <div class="llar-upgrade-subscribe">

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -51,7 +51,7 @@ if ( $is_active_app_custom ) {
                     <span class="dashicons dashicons-superhero"></span>
                     <?php
 					echo sprintf(
-                        __( 'You have exhausted your monthly quota of free Micro Cloud requests. The plugin has now reverted to the free version. <a href="%s" class="link__style_color_inherit" target="_blank">Upgrade to the premium</a> version today to maintain cloud protection and advanced features.', 'limit-login-attempts-reloaded' ),
+                        __( 'Your 14 day free trial has ended and the plugin has reverted to the free version. <a href="%s" class="link__style_color_inherit" target="_blank">Upgrade to Premium</a> to restore cloud protection and advanced features.', 'limit-login-attempts-reloaded' ),
                         add_query_arg('id', '4', $upgrade_premium_url) );
                     ?>
                 </p>

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -67,7 +67,7 @@ if ( $is_active_app_custom ) {
                 <span class="dashicons dashicons-superhero"></span>
 				<?php
 				echo sprintf(
-					__( 'Enjoying Micro Cloud? To prevent interruption of the cloud app, <a href="%s" class="link__style_color_inherit" target="_blank">Upgrade to Premium</a> today', 'limit-login-attempts-reloaded' ),
+					__( 'Enjoying your free trial? To prevent interruption of the cloud app, <a href="%s" class="link__style_color_inherit" target="_blank">Upgrade to Premium</a> today', 'limit-login-attempts-reloaded' ),
 					add_query_arg('id', '4', $upgrade_premium_url) );
 				?>
             </p>

--- a/views/tab-dashboard.php
+++ b/views/tab-dashboard.php
@@ -68,9 +68,9 @@ if ( ! $is_active_app_custom && empty( $setup_code ) ) {
             </div>
             <div class="actions">
                 <div class="actions__buttons actions__buttons--centered">
-                    <a title="<?php esc_attr_e( 'Get Started', 'limit-login-attempts-reloaded' ); ?>"
+                    <a title="<?php esc_attr_e( '14 Day Trial', 'limit-login-attempts-reloaded' ); ?>"
                        class="button menu__item button__orange button_micro_cloud link__style_unlink">
-                        <?php _e( 'Get Started', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( '14 Day Trial', 'limit-login-attempts-reloaded' ); ?>
                     </a>
                 </div>
             </div>

--- a/views/tab-dashboard.php
+++ b/views/tab-dashboard.php
@@ -49,38 +49,29 @@ if ( ! $is_active_app_custom && empty( $setup_code ) ) {
         <?php if ( ! $is_active_app_custom && empty( $setup_code ) ) : ?>
 		<div class="info-box-3">
             <div class="section-title__new">
-                <div class="title"><?php _e( 'Enable Micro Cloud (FREE)', 'limit-login-attempts-reloaded' ); ?></div>
+                <div class="title"><?php _e( 'Experience Premium Free for 14 Days', 'limit-login-attempts-reloaded' ); ?></div>
             </div>
             <div class="section-content">
                 <div class="desc">
                     <ul class="list-unstyled">
                         <li class="star">
-                            <?php _e( 'Help us secure our network by providing access to your login IP data.', 'limit-login-attempts-reloaded' ); ?>
+                            <?php _e( 'No credit card required. Automatically revert to the free version when the trial is complete.', 'limit-login-attempts-reloaded' ); ?>
                         </li>
                         <li class="star">
-                            <?php _e( 'In return, receive access to our premium features up to 1,000 requests per month, and 100 for each subsequent month.', 'limit-login-attempts-reloaded' ); ?>
+                            <?php _e( 'Unlock advanced security features including Cloud Protection, Block by Country, Login Firewall, and Successful Login Logs', 'limit-login-attempts-reloaded' ); ?>
                         </li>
                         <li class="star">
-                            <?php _e( 'Once the allocated requests are consumed, the premium app will switch back to the free version and reset the following month.', 'limit-login-attempts-reloaded' ); ?>
+                            <?php _e( 'Stop brute force attacks before they reach your login page with one of the strongest login protection systems for WordPress', 'limit-login-attempts-reloaded' ); ?>
                         </li>
                     </ul>
                 </div>
             </div>
             <div class="actions">
-                <div class="actions__buttons">
-                    <a href="https://www.limitloginattempts.com/premium-security-zero-cost-discover-the-benefits-of-micro-cloud/"
-                       title="Learn More"
-                       target="_blank"
-                       class="button menu__item button__transparent_orange link__style_unlink">
-                        <?php _e( 'Learn More', 'limit-login-attempts-reloaded' ); ?>
-                    </a>
-                    <a title="Upgrade To Micro Cloud"
+                <div class="actions__buttons actions__buttons--centered">
+                    <a title="<?php esc_attr_e( 'Get Started', 'limit-login-attempts-reloaded' ); ?>"
                        class="button menu__item button__orange button_micro_cloud link__style_unlink">
                         <?php _e( 'Get Started', 'limit-login-attempts-reloaded' ); ?>
                     </a>
-                </div>
-                <div class="remark">
-	                <?php _e( '* A request is utilized when our cloud app validates an IP before it is able to perform a login attempt.', 'limit-login-attempts-reloaded' ); ?>
                 </div>
             </div>
         </div>

--- a/views/tab-logs-custom.php
+++ b/views/tab-logs-custom.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) exit();
                     <img src="<?php echo LLA_PLUGIN_URL ?>assets/css/images/micro-cloud-image-min.png">
                 </div>
                 <div class="col-second">
-	                <?php _e( 'Your Micro Cloud plan has exhausted its requests for the month, which is required to operate the Login Firewall.', 'limit-login-attempts-reloaded' ) ?>
+	                <?php _e( 'Your 14 day free trial has ended, which is required to operate the Login Firewall.', 'limit-login-attempts-reloaded' ) ?>
                 </div>
                 <div class="col-third">
                     <div class="row-first">

--- a/views/tab-logs-local.php
+++ b/views/tab-logs-local.php
@@ -151,7 +151,7 @@ $url_try_for_free = 'https://www.limitloginattempts.com/upgrade/?from=plugin-';
                     <?php _e( 'Upgrade To Premium For Our Login Firewall', 'limit-login-attempts-reloaded' ); ?>
                 </div>
                 <a href="https://www.limitloginattempts.com/info.php?id=20" class="button menu__item button__transparent_orange mt-1_5" target="_blank">
-                    <?php _e( 'Try For FREE', 'limit-login-attempts-reloaded' ); ?>
+                    <?php _e( '14 Day Trial', 'limit-login-attempts-reloaded' ); ?>
                 </a>
             </div>
             <div class="add_block__list">
@@ -259,7 +259,7 @@ $url_try_for_free = 'https://www.limitloginattempts.com/upgrade/?from=plugin-';
                         <?php _e( 'Upgrade Today For Enhanced Logs & IP Intelligence', 'limit-login-attempts-reloaded' ); ?>
                     </div>
                     <a href="<?php echo $url_try_for_free . 'logs-log' ?>" class="button menu__item button__transparent_orange mt-1_5" target="_blank">
-                        <?php _e( 'Try For FREE', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( '14 Day Trial', 'limit-login-attempts-reloaded' ); ?>
                     </a>
                 </div>
                 <div class="add_block__list">

--- a/views/tab-premium.php
+++ b/views/tab-premium.php
@@ -39,7 +39,7 @@ $is_premium = ( $is_active_app_custom && $plans[$block_sub_group] >= $plans[$min
             <div class="text">
                 <div class="title">
                     <?php if ( $block_sub_group && $block_sub_group === 'Micro Cloud' ) : ?>
-                        <?php _e( 'Limit Login Attempts Reloaded <strong>Micro Cloud</strong>', 'limit-login-attempts-reloaded' ); ?>
+                        <?php _e( 'Limit Login Attempts Reloaded <strong>Free Trial</strong>', 'limit-login-attempts-reloaded' ); ?>
                     <?php else : ?>
 	                    <?php _e( 'Limit Login Attempts Reloaded <strong>Premium</strong>', 'limit-login-attempts-reloaded' ); ?>
                     <?php endif; ?>
@@ -85,7 +85,7 @@ $is_premium = ( $is_active_app_custom && $plans[$block_sub_group] >= $plans[$min
                 </span>
             <?php elseif( $block_sub_group ) : ?>
                 <?php if( $block_sub_group === 'Micro Cloud' ) : ?>
-                    <?php _e( 'You are currently using Micro Cloud, which provides access to premium cloud app on a limited basis. To prevent interruption, upgrade to one of our paid plans below.', 'limit-login-attempts-reloaded' ); ?>
+                    <?php _e( 'You are currently using the 14 day free trial, which provides access to the premium cloud app on a limited basis. To prevent interruption, upgrade to one of our paid plans below.', 'limit-login-attempts-reloaded' ); ?>
                 <?php else : ?>
                     <?php _e( 'You are currently using the premium version of Limit Login Attempts Reloaded.', 'limit-login-attempts-reloaded' ); ?>
 	            <?php endif ?>

--- a/views/tab-premium.php
+++ b/views/tab-premium.php
@@ -7,14 +7,9 @@
  *
  */
 
-use LLAR\Core\Config;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
-
-$setup_code = Config::get( 'app_setup_code' );
-$is_local_no_empty_setup_code = ( ! $is_active_app_custom && ! empty( $setup_code ) );
 
 $min_plan = 'Premium';
 $plans = $this->array_name_plans();
@@ -118,19 +113,10 @@ $is_premium = ( $is_active_app_custom && $plans[$block_sub_group] >= $plans[$min
         $features = array(
             'Features',
             'Free',
-            'Micro Cloud',
             'Premium',
             'Premium +',
             'Professional',
         );
-
-        if ( $is_local_no_empty_setup_code ) {
-	        $key = array_search('Micro Cloud', $features);
-
-	        if ($key !== false) {
-		        unset($features[$key]);
-	        }
-        }
 
         $compare_list = require LLA_PLUGIN_DIR . '/resources/compare-plans-data.php';
     ?>

--- a/views/tab-settings.php
+++ b/views/tab-settings.php
@@ -307,7 +307,7 @@ $url_try_for_free_cloud     = ( $is_active_app_custom ) ? $this->info_upgrade_ur
 	                    <?php if ( $is_local_empty_setup_code ) : ?>
 		                    <?php require_once( LLA_PLUGIN_DIR . 'views/micro-cloud-modal.php') ?>
                             <a class="button menu__item button_micro_cloud button__transparent_orange" target="_blank">
-			                    <?php _e( 'Try For FREE', 'limit-login-attempts-reloaded' ); ?>
+			                    <?php _e( '14 Day Trial', 'limit-login-attempts-reloaded' ); ?>
                             </a>
                         <?php elseif ( $block_sub_group === 'Micro Cloud' ) : ?>
                             <a href="<?php echo esc_url( $url_try_for_free_cloud ) ?>" class="button menu__item button__transparent_orange" target="_blank">
@@ -414,7 +414,7 @@ $url_try_for_free_cloud     = ( $is_active_app_custom ) ? $this->info_upgrade_ur
                                 </div>
 	                            <?php if ( $is_local_empty_setup_code ) : ?>
                                     <a class="button menu__item button_micro_cloud button__transparent_orange mt-1_5" target="_blank">
-			                            <?php _e( 'Try For FREE', 'limit-login-attempts-reloaded' ); ?>
+			                            <?php _e( '14 Day Trial', 'limit-login-attempts-reloaded' ); ?>
                                     </a>
 	                            <?php elseif ( $block_sub_group === 'Micro Cloud' ) : ?>
                                     <a href="<?php echo esc_url( add_query_arg('id', '6', $url_try_for_free_cloud)) ?>" class="button menu__item button__transparent_orange mt-1_5" target="_blank">

--- a/views/tab-settings.php
+++ b/views/tab-settings.php
@@ -68,41 +68,6 @@ $url_try_for_free_cloud     = ( $is_active_app_custom ) ? $this->info_upgrade_ur
             </div>
             <div class="llar-settings-wrap">
                 <table class="llar-form-table">
-	                <?php if ( $is_local_empty_setup_code ) : ?>
-                    <tr>
-                        <th scope="row" valign="top"><?php _e( 'Micro Cloud', 'limit-login-attempts-reloaded' ); ?>
-                            <span class="hint_tooltip-parent">
-                                <span class="dashicons dashicons-editor-help"></span>
-                                <div class="hint_tooltip">
-                                    <div class="hint_tooltip-content">
-                                        <?php _e( 'Micro Cloud is a limited upgrade to our cloud app that provides complimentary access to our premium features', 'limit-login-attempts-reloaded' ); ?>
-                                    </div>
-                                </div>
-                            </span>
-                        </th>
-                        <td>
-                            <div class="description-secondary p-0">
-								<?php _e('Help us secure our network by sharing your login IP data. In return, receive limited access to our premium features up to 1,000 requests for the first month, and 100 requests each subsequent month. Once requests are exceeded for a given month, the premium app will switch to FREE and reset the following month.', 'limit-login-attempts-reloaded' ) ?>
-                            </div>
-                            <div class="description-additional p-0 pt-1_5">
-		                        <?php _e('* Requests are utilized when the cloud app validates an IP address before it is able to perform a login.', 'limit-login-attempts-reloaded' ) ?>
-                            </div>
-                            <div class="button_block">
-                                <a href="https://www.limitloginattempts.com/premium-security-zero-cost-discover-the-benefits-of-micro-cloud/"
-                                   title="Learn More"
-                                   target="_blank"
-                                   class="button menu__item button__transparent_orange link__style_unlink">
-		                            <?php _e( 'Learn More', 'limit-login-attempts-reloaded' ); ?>
-                                </a>
-                                <a title="Upgrade To Micro Cloud"
-                                   class="button menu__item button__orange button_micro_cloud link__style_unlink">
-		                            <?php _e( 'Get Started', 'limit-login-attempts-reloaded' ); ?>
-                                </a>
-                            </div>
-                        </td>
-                    </tr>
-	                <?php endif; ?>
-
                     <tr>
                         <th scope="row" valign="top"><?php _e( 'Active App', 'limit-login-attempts-reloaded' ); ?>
                             <span class="hint_tooltip-parent">
@@ -126,14 +91,6 @@ $url_try_for_free_cloud     = ( $is_active_app_custom ) ? $this->info_upgrade_ur
                                     </option>
 								<?php endif; ?>
                             </select>
-							<?php if ( ! $is_active_app_custom ) : ?>
-                                <span class="llar-protect-notice">
-                                    <?php echo sprintf(
-		                                __( 'Get advanced protection by <a href="%s" class="unlink llar-upgrade-to-cloud">upgrading to our Cloud App</a>.', 'limit-login-attempts-reloaded' ),
-                                '#' );
-                                ?>
-                                    </span>
-							<?php endif; ?>
                         </td>
                     </tr>
                 </table>
@@ -786,17 +743,6 @@ $url_try_for_free_cloud     = ( $is_active_app_custom ) ? $this->info_upgrade_ur
                         }, 200)
 
                     })
-
-
-                    $( '.llar-upgrade-to-cloud' ).on( 'click', function ( e ) {
-                        e.preventDefault();
-
-                        $( "#ui-id-3" ).click();
-
-                        $( [document.documentElement, document.body] ).animate( {
-                            scrollTop: $( "#llar-apps-accordion" ).offset().top
-                        }, 500 );
-                    } );
 
                     $( '.llar-test-email-notification-btn' ).on( 'click', function ( e ) {
                         e.preventDefault();


### PR DESCRIPTION
## Summary
- Replace the Micro Cloud offering with a 14 day free trial narrative across the dashboard, settings, premium comparison, onboarding popup and activation modal
- Remove the Micro Cloud plan column from the Premium/Extensions comparison table and drop the now-unused protect-notice markup, styles and dead JS handler
- Update remaining user-facing copy (email notification, banners, legacy status messages) to consistent trial wording

## Details
- Dashboard: new "Experience Premium Free for 14 Days" block with updated bullets, centered CTA, removed Learn More button and request remark
- Onboarding: "Unlock Premium FREE for 14 Days" with "No Credit Card Required", updated feature copy and trial call to action
- Comparison table: Micro Cloud column removed; "Upgrade now" trial buttons say "14 Day Trial"
- Activation modal: rebranded to the free trial flow (internal JS identifiers left untouched)
- Internal logic (`$block_sub_group === 'Micro Cloud'` checks, plan map, CSS/JS class names) kept for backward compatibility with existing trial users