### PR TITLE
fix: avoid implicit float-to-int in notify email check

### DIFF
--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -2546,7 +2546,7 @@ class LimitLoginAttempts
 		/* check if we are at the right nr to do notification */
 		if (
 			isset( $retries[ $ip ] )
-			&& ( ( (int) $retries[ $ip ] / Config::get( 'allowed_retries' ) ) % $notify_email_after ) != 0
+			&& 0 != ( (int) floor( (int) $retries[ $ip ] / Config::get( 'allowed_retries' ) ) % $notify_email_after )
 		) {
 			return;
 		}


### PR DESCRIPTION
## Summary
- Fix PHP 8.1+ Deprecated warning in `notify_email()` when computing lockout count before modulo
- Use explicit `(int) floor(...)` and Yoda condition for the email notification interval check