### PR TITLE
fix: make digest Daily/Weekly/Monthly labels translatable

### DIFF
--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -2546,7 +2546,7 @@ class LimitLoginAttempts
 		/* check if we are at the right nr to do notification */
 		if (
 			isset( $retries[ $ip ] )
-			&& ( ( (int) $retries[ $ip ] / Config::get( 'allowed_retries' ) ) % $notify_email_after ) != 0
+			&& 0 != ( (int) floor( (int) $retries[ $ip ] / Config::get( 'allowed_retries' ) ) % $notify_email_after )
 		) {
 			return;
 		}

--- a/core/digest/DigestDispatcher.php
+++ b/core/digest/DigestDispatcher.php
@@ -338,7 +338,7 @@ class DigestDispatcher {
 		}
 
 		ob_start();
-		echo self::build_preview_text_html( $definition );
+		echo self::build_preview_text_html( $digest_key );
 		include $template_path;
 		return (string) ob_get_clean();
 	}
@@ -346,15 +346,15 @@ class DigestDispatcher {
 	/**
 	 * Build hidden preheader HTML for inbox preview snippet (Gmail, etc.).
 	 *
-	 * @param array $definition Digest definition from LLA_DIGEST_DEFINITIONS.
+	 * @param string $digest_key Digest key (daily/weekly/monthly).
 	 * @return string
 	 */
-	public static function build_preview_text_html( $definition ) {
-		if ( empty( $definition['preview_text'] ) ) {
+	public static function build_preview_text_html( $digest_key ) {
+		$preview_text = DigestUiController::get_digest_preview_text( $digest_key );
+
+		if ( '' === $preview_text ) {
 			return '';
 		}
-
-		$preview_text = (string) $definition['preview_text'];
 
 		ob_start();
 		include LLA_PLUGIN_DIR . 'views/emails/email-preview-text.php';

--- a/core/digest/DigestDispatcher.php
+++ b/core/digest/DigestDispatcher.php
@@ -287,10 +287,7 @@ class DigestDispatcher {
 	 */
 	private static function build_subject( $digest_key, $lockouts_total ) {
 		$site_domain = str_replace( array( 'http://', 'https://' ), '', home_url() );
-		$definitions = self::get_definitions();
-		$label       = ! empty( $definitions[ $digest_key ]['name'] )
-			? (string) $definitions[ $digest_key ]['name']
-			: ucfirst( $digest_key );
+		$label       = DigestUiController::get_digest_label( $digest_key );
 
 		return sprintf(
 			'%1$s Security Summary for %2$s: %3$d lockouts',

--- a/core/digest/DigestUiController.php
+++ b/core/digest/DigestUiController.php
@@ -53,14 +53,39 @@ class DigestUiController {
 	 * @return string
 	 */
 	public static function get_digest_label( $digest_key ) {
-		$digest_key  = sanitize_key( (string) $digest_key );
-		$definitions = self::get_definitions();
+		$digest_key = sanitize_key( (string) $digest_key );
 
-		if ( empty( $definitions[ $digest_key ]['name'] ) ) {
-			return ucfirst( $digest_key );
+		switch ( $digest_key ) {
+			case 'daily':
+				return __( 'Daily', 'limit-login-attempts-reloaded' );
+			case 'weekly':
+				return __( 'Weekly', 'limit-login-attempts-reloaded' );
+			case 'monthly':
+				return __( 'Monthly', 'limit-login-attempts-reloaded' );
 		}
 
-		return __( (string) $definitions[ $digest_key ]['name'], 'limit-login-attempts-reloaded' );
+		return ucfirst( $digest_key );
+	}
+
+	/**
+	 * Translated digest email preheader for inbox preview snippet.
+	 *
+	 * @param string $digest_key Digest definition key (daily/weekly/monthly).
+	 * @return string
+	 */
+	public static function get_digest_preview_text( $digest_key ) {
+		$digest_key = sanitize_key( (string) $digest_key );
+
+		switch ( $digest_key ) {
+			case 'daily':
+				return __( 'Daily digest of lockouts, top IPs, and what to review next.', 'limit-login-attempts-reloaded' );
+			case 'weekly':
+				return __( 'Weekly digest of lockouts, top IPs, and what to review next.', 'limit-login-attempts-reloaded' );
+			case 'monthly':
+				return __( 'Monthly digest of lockouts, top IPs, and what to review next.', 'limit-login-attempts-reloaded' );
+		}
+
+		return '';
 	}
 
 	/**

--- a/core/digest/DigestUiController.php
+++ b/core/digest/DigestUiController.php
@@ -37,13 +37,32 @@ class DigestUiController {
 			$option_key   = self::get_option_key( $digest_key );
 			$checkboxes[] = array(
 				'name'             => $option_key,
-				'label'            => isset( $digest_definition['name'] ) ? (string) $digest_definition['name'] : $digest_key,
+				'label'            => self::get_digest_label( $digest_key ),
 				'checked'          => (bool) Config::get( $option_key ),
 				'interval_seconds' => isset( $digest_definition['interval_seconds'] ) ? (int) $digest_definition['interval_seconds'] : 0,
 			);
 		}
 
 		return $checkboxes;
+	}
+
+	/**
+	 * Translated digest label for UI and email subject.
+	 *
+	 * @param string $digest_key Digest definition key (daily/weekly/monthly).
+	 * @return string
+	 */
+	public static function get_digest_label( $digest_key ) {
+		switch ( $digest_key ) {
+			case 'daily':
+				return __( 'Daily', 'limit-login-attempts-reloaded' );
+			case 'weekly':
+				return __( 'Weekly', 'limit-login-attempts-reloaded' );
+			case 'monthly':
+				return __( 'Monthly', 'limit-login-attempts-reloaded' );
+			default:
+				return ucfirst( $digest_key );
+		}
 	}
 
 	/**

--- a/core/digest/DigestUiController.php
+++ b/core/digest/DigestUiController.php
@@ -53,16 +53,14 @@ class DigestUiController {
 	 * @return string
 	 */
 	public static function get_digest_label( $digest_key ) {
-		switch ( $digest_key ) {
-			case 'daily':
-				return __( 'Daily', 'limit-login-attempts-reloaded' );
-			case 'weekly':
-				return __( 'Weekly', 'limit-login-attempts-reloaded' );
-			case 'monthly':
-				return __( 'Monthly', 'limit-login-attempts-reloaded' );
-			default:
-				return ucfirst( $digest_key );
+		$digest_key  = sanitize_key( (string) $digest_key );
+		$definitions = self::get_definitions();
+
+		if ( empty( $definitions[ $digest_key ]['name'] ) ) {
+			return ucfirst( $digest_key );
 		}
+
+		return __( (string) $definitions[ $digest_key ]['name'], 'limit-login-attempts-reloaded' );
 	}
 
 	/**

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -140,16 +140,21 @@ define( 'LLA_LOCKOUT_NOTIFY_ALLOWED', 'log,email' );
 defined( 'LLA_LOCKOUT_HISTORY_RETENTION_DAYS' ) || define( 'LLA_LOCKOUT_HISTORY_RETENTION_DAYS', 60 );
 defined( 'LLA_DIGEST_DISPATCH_HOUR_LOCAL' ) || define( 'LLA_DIGEST_DISPATCH_HOUR_LOCAL', 10 );
 
+defined( 'LLA_DIGEST_LABEL_DAILY' ) || define( 'LLA_DIGEST_LABEL_DAILY', 'Daily' );
+defined( 'LLA_DIGEST_LABEL_WEEKLY' ) || define( 'LLA_DIGEST_LABEL_WEEKLY', 'Weekly' );
+defined( 'LLA_DIGEST_LABEL_MONTHLY' ) || define( 'LLA_DIGEST_LABEL_MONTHLY', 'Monthly' );
+
 /**
  * Digest definitions (name, interval, templates). Default on/off profiles for new vs
  * existing installs are defined in Config::get_digest_defaults_for_*_install().
+ * Label strings: LLA_DIGEST_LABEL_DAILY, LLA_DIGEST_LABEL_WEEKLY, LLA_DIGEST_LABEL_MONTHLY.
  * Format: {key: {name: string, interval_seconds: int, is_default: bool, ...}}
  */
 defined( 'LLA_DIGEST_DEFINITIONS' ) || define(
 	'LLA_DIGEST_DEFINITIONS',
 	array(
 		'daily' => array(
-			'name' => 'Daily',
+			'name' => LLA_DIGEST_LABEL_DAILY,
 			'interval_seconds' => DAY_IN_SECONDS,
 			'is_default' => true,
 			'email_template' => 'digest-daily-content.php',
@@ -160,7 +165,7 @@ defined( 'LLA_DIGEST_DEFINITIONS' ) || define(
 			'title_mode' => 'date',
 		),
 		'weekly' => array(
-			'name' => 'Weekly',
+			'name' => LLA_DIGEST_LABEL_WEEKLY,
 			'interval_seconds' => WEEK_IN_SECONDS,
 			'is_default' => true,
 			'email_template' => 'digest-weekly-content.php',
@@ -171,7 +176,7 @@ defined( 'LLA_DIGEST_DEFINITIONS' ) || define(
 			'title_mode' => 'range',
 		),
 		'monthly' => array(
-			'name' => 'Monthly',
+			'name' => LLA_DIGEST_LABEL_MONTHLY,
 			'interval_seconds' => MONTH_IN_SECONDS,
 			'is_default' => true,
 			'email_template' => 'digest-monthly-content.php',

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -140,49 +140,42 @@ define( 'LLA_LOCKOUT_NOTIFY_ALLOWED', 'log,email' );
 defined( 'LLA_LOCKOUT_HISTORY_RETENTION_DAYS' ) || define( 'LLA_LOCKOUT_HISTORY_RETENTION_DAYS', 60 );
 defined( 'LLA_DIGEST_DISPATCH_HOUR_LOCAL' ) || define( 'LLA_DIGEST_DISPATCH_HOUR_LOCAL', 10 );
 
-defined( 'LLA_DIGEST_LABEL_DAILY' ) || define( 'LLA_DIGEST_LABEL_DAILY', 'Daily' );
-defined( 'LLA_DIGEST_LABEL_WEEKLY' ) || define( 'LLA_DIGEST_LABEL_WEEKLY', 'Weekly' );
-defined( 'LLA_DIGEST_LABEL_MONTHLY' ) || define( 'LLA_DIGEST_LABEL_MONTHLY', 'Monthly' );
-
 /**
- * Digest definitions (name, interval, templates). Default on/off profiles for new vs
+ * Digest definitions (interval, templates). Default on/off profiles for new vs
  * existing installs are defined in Config::get_digest_defaults_for_*_install().
- * Label strings: LLA_DIGEST_LABEL_DAILY, LLA_DIGEST_LABEL_WEEKLY, LLA_DIGEST_LABEL_MONTHLY.
- * Format: {key: {name: string, interval_seconds: int, is_default: bool, ...}}
+ * Format: {key: {interval_seconds: int, is_default: bool, ...}}
+ *
+ * Translatable digest strings (labels and email preheaders) are not stored here.
+ * Add or change them in DigestUiController::get_digest_label() and
+ * DigestUiController::get_digest_preview_text() so i18n tools can extract literals.
  */
 defined( 'LLA_DIGEST_DEFINITIONS' ) || define(
 	'LLA_DIGEST_DEFINITIONS',
 	array(
 		'daily' => array(
-			'name' => LLA_DIGEST_LABEL_DAILY,
 			'interval_seconds' => DAY_IN_SECONDS,
 			'is_default' => true,
 			'email_template' => 'digest-daily-content.php',
 			'show_threat_level' => false,
 			'intro_text' => '',
-			'preview_text' => 'Daily digest of lockouts, top IPs, and what to review next.',
 			'unsubscribe_text' => '{unsubscribe}',
 			'title_mode' => 'date',
 		),
 		'weekly' => array(
-			'name' => LLA_DIGEST_LABEL_WEEKLY,
 			'interval_seconds' => WEEK_IN_SECONDS,
 			'is_default' => true,
 			'email_template' => 'digest-weekly-content.php',
 			'show_threat_level' => true,
 			'intro_text' => '',
-			'preview_text' => 'Weekly digest of lockouts, top IPs, and what to review next.',
 			'unsubscribe_text' => '{unsubscribe}',
 			'title_mode' => 'range',
 		),
 		'monthly' => array(
-			'name' => LLA_DIGEST_LABEL_MONTHLY,
 			'interval_seconds' => MONTH_IN_SECONDS,
 			'is_default' => true,
 			'email_template' => 'digest-monthly-content.php',
 			'show_threat_level' => true,
 			'intro_text' => '',
-			'preview_text' => 'Monthly digest of lockouts, top IPs, and what to review next.',
 			'unsubscribe_text' => '{unsubscribe}',
 			'title_mode' => 'month',
 		),


### PR DESCRIPTION
## Summary
- Add `LLA_DIGEST_LABEL_DAILY`, `LLA_DIGEST_LABEL_WEEKLY`, and `LLA_DIGEST_LABEL_MONTHLY` constants and use them in `LLA_DIGEST_DEFINITIONS`.
- Add `DigestUiController::get_digest_label()` to translate definition `name` values for Email Digests settings checkboxes and digest email subjects.