### PR TITLE
fix(dashboard): handle /info API errors in cloud dashboard UI

### DIFF
--- a/core/CloudApp.php
+++ b/core/CloudApp.php
@@ -321,8 +321,10 @@ class CloudApp
             $message .= ' (' . implode( '; ', $details ) . ')';
         }
 
-        echo '<div class="notice notice-error" style="display: block;"><p>' . esc_html( $message ) . '</p>';
-        echo '<p><a href="javascript:void(0);" onclick="window.location.reload();" class="button button-primary">' . esc_html__( 'Click here to refresh the page', 'limit-login-attempts-reloaded' ) . '</a></p></div>';
+        $refresh_label = __( 'Click here to refresh the page', 'limit-login-attempts-reloaded' );
+
+        echo '<div class="notice notice-error" style="display: block;"><p>' . $message . '</p>';
+        echo '<p><a href="javascript:void(0);" onclick="window.location.reload();" class="button button-primary">' . esc_html( $refresh_label ) . '</a></p></div>';
     }
 
 	/**

--- a/core/CloudApp.php
+++ b/core/CloudApp.php
@@ -230,38 +230,99 @@ class CloudApp
      */
     public function info()
     {
-        $info = $this->request( 'info' );
-        if ( ! $info  && ! defined( 'LLAR_FAILED_INFO_NOTICE_SHOWN' )) {
+        $info = $this->request_info();
+
+        if ( ! $info && ! defined( 'LLAR_FAILED_INFO_NOTICE_SHOWN' ) && $this->is_info_network_failure() ) {
             define( 'LLAR_FAILED_INFO_NOTICE_SHOWN', true );
-            $details = array();
-
-            if ( null !== $this->last_response_code ) {
-                $details[] = sprintf(
-                    /* translators: %d: HTTP response code. */
-                    __( 'Code: %d', 'limit-login-attempts-reloaded' ),
-                    intval( $this->last_response_code )
-                );
-            }
-
-            if ( ! empty( $this->last_error_message ) ) {
-                $details[] = sprintf(
-                    /* translators: %s: technical error reason. */
-                    __( 'Reason: %s', 'limit-login-attempts-reloaded' ),
-                    esc_html( $this->get_readable_error_reason( $this->last_error_message ) )
-                );
-            }
-
-            $message = __( 'Oops, it looks like the site is having a temporary network issue.', 'limit-login-attempts-reloaded' );
-
-            if ( ! empty( $details ) ) {
-                $message .= ' (' . implode( '; ', $details ) . ')';
-            }
-
-            echo '<div class="notice notice-error" style="display: block;"><p>' . $message . '</p>';
-            echo '<p><a href="javascript:void(0);" onclick="window.location.reload();" class="button button-primary">' . __( 'Click here to refresh the page', 'limit-login-attempts-reloaded' ) . '</a></p></div>';
+            $this->render_info_network_failure_notice();
         }
 
         return $info;
+    }
+
+    /**
+     * Whether the last /info call failed before reaching the Cloud API (transport / DNS / timeout).
+     *
+     * @return bool
+     */
+    public function is_info_network_failure()
+    {
+        if ( 0 < (int) $this->last_response_code ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool|mixed
+     * @throws Exception
+     */
+    private function request_info()
+    {
+        if ( ! $this->api ) {
+            throw new Exception( 'Cloud API endpoint is not configured.' );
+        }
+
+        $headers   = array();
+        $headers[] = "{$this->config['header']}: {$this->config['key']}";
+
+        $response = Http::get(
+            $this->api . '/info',
+            array(
+                'headers' => $headers,
+            )
+        );
+
+        $this->last_response_code = ! empty( $response['status'] ) ? $response['status'] : 0;
+        $this->last_error_message = ! empty( $response['error'] ) ? $response['error'] : null;
+
+        $info = false;
+        if ( ! empty( $response['data'] ) ) {
+            $decoded = json_decode( $response['data'], true );
+            if ( is_array( $decoded ) && ! empty( $decoded ) ) {
+                $info = Helpers::sanitize_stripslashes_deep( $decoded );
+            }
+        }
+
+        if ( 200 !== (int) $this->last_response_code ) {
+            error_log( 'LLAR: CloudApp info request failed: ' . $this->api . '/info ' . $this->last_response_code );
+        }
+
+        return $info;
+    }
+
+    /**
+     * Admin notice when /info could not reach the Cloud API at all.
+     */
+    private function render_info_network_failure_notice()
+    {
+        $details = array();
+
+        if ( null !== $this->last_response_code ) {
+            $details[] = sprintf(
+                /* translators: %d: HTTP response code. */
+                __( 'Code: %d', 'limit-login-attempts-reloaded' ),
+                intval( $this->last_response_code )
+            );
+        }
+
+        if ( ! empty( $this->last_error_message ) ) {
+            $details[] = sprintf(
+                /* translators: %s: technical error reason. */
+                __( 'Reason: %s', 'limit-login-attempts-reloaded' ),
+                esc_html( $this->get_readable_error_reason( $this->last_error_message ) )
+            );
+        }
+
+        $message = __( 'Oops, it looks like the site is having a temporary network issue.', 'limit-login-attempts-reloaded' );
+
+        if ( ! empty( $details ) ) {
+            $message .= ' (' . implode( '; ', $details ) . ')';
+        }
+
+        echo '<div class="notice notice-error" style="display: block;"><p>' . esc_html( $message ) . '</p>';
+        echo '<p><a href="javascript:void(0);" onclick="window.location.reload();" class="button button-primary">' . esc_html__( 'Click here to refresh the page', 'limit-login-attempts-reloaded' ) . '</a></p></div>';
     }
 
 	/**

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -3786,6 +3786,48 @@ class LimitLoginAttempts
 		return isset( $this->info_data['requests']['exhausted'] ) ? filter_var( $this->info_data['requests']['exhausted'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) : false;
 	}
 
+	/**
+	 * Whether /info returned usable quota and plan data for the dashboard UI.
+	 *
+	 * @return bool
+	 */
+	public function info_has_valid_data()
+	{
+		if ( empty( $this->info_data ) ) {
+
+			$this->info_data = $this->info();
+		}
+
+		if ( empty( $this->info_data ) || ! is_array( $this->info_data ) ) {
+			return false;
+		}
+
+		if ( empty( $this->info_data['requests'] ) || ! is_array( $this->info_data['requests'] ) ) {
+			return false;
+		}
+
+		return array_key_exists( 'quota', $this->info_data['requests'] )
+			&& '' !== (string) $this->info_data['requests']['quota'];
+	}
+
+	/**
+	 * Cloud API responded to /info but access is denied (e.g. quota exhausted or unpaid domain).
+	 *
+	 * @return bool
+	 */
+	public function info_is_cloud_unavailable()
+	{
+		if ( ! self::$cloud_app ) {
+			return false;
+		}
+
+		if ( $this->info_has_valid_data() ) {
+			return false;
+		}
+
+		return ! self::$cloud_app->is_info_network_failure();
+	}
+
 
 	public function info_requests()
 	{

--- a/core/LimitLoginAttempts.php
+++ b/core/LimitLoginAttempts.php
@@ -3794,7 +3794,6 @@ class LimitLoginAttempts
 	public function info_has_valid_data()
 	{
 		if ( empty( $this->info_data ) ) {
-
 			$this->info_data = $this->info();
 		}
 

--- a/limit-login-attempts-reloaded.php
+++ b/limit-login-attempts-reloaded.php
@@ -22,6 +22,9 @@ define( 'LLA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LLA_PLUGIN_FILE', __FILE__ );
 define( 'LLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
+/** Fallback premium upgrade URL when Cloud App /v1/info does not return upgrade_url. */
+defined( 'LLA_INFO_UPGRADE_FALLBACK_URL' ) || define( 'LLA_INFO_UPGRADE_FALLBACK_URL', 'https://www.limitloginattempts.com/info.php?id=0' );
+
 /**
  * Default risk widget config (bounds, colors, level rules).
  *

--- a/views/admin-dashboard-widgets.php
+++ b/views/admin-dashboard-widgets.php
@@ -15,11 +15,13 @@ $is_active_app_custom = $active_app === 'custom';
 if ( $is_active_app_custom ) {
 
 	$is_exhausted = $this->info_is_exhausted();
+	$info_has_valid_data = $this->info_has_valid_data();
 	$block_sub_group = $this->info_sub_group();
 	$upgrade_premium_url = $this->info_upgrade_url();
 } else {
 
 	$is_exhausted = false;
+	$info_has_valid_data = false;
 	$block_sub_group = '';
 	$upgrade_premium_url = '';
 }

--- a/views/chart-circle-failed-attempts-today.php
+++ b/views/chart-circle-failed-attempts-today.php
@@ -7,6 +7,7 @@
  * @var string $is_active_app_custom
  * @var bool|mixed $api_stats
  * @var bool|string $is_exhausted
+ * @var bool $info_has_valid_data
  * @var string $block_sub_group
  * @var string $upgrade_premium_url
  *
@@ -44,7 +45,7 @@ $retries_count       = isset( $chart_circle_data['retries_count'] ) ? (int) $cha
         <span class="llar-label__url">
         </span>
 	<?php endif; ?>
-	<?php echo ( $is_active_app_custom && ! $is_exhausted )
+	<?php echo ( $is_active_app_custom && ! empty( $info_has_valid_data ) && ! $is_exhausted )
 		? '<span class="llar-premium-label"><span class="dashicons dashicons-saved"></span>' . __( 'Cloud protection enabled', 'limit-login-attempts-reloaded' ) . '</span>'
 		: ''; ?>
 </div>

--- a/views/chart-failed-attempts.php
+++ b/views/chart-failed-attempts.php
@@ -8,6 +8,7 @@
  * @var bool $is_agency
  * @var array $requests
  * @var bool|string $is_exhausted
+ * @var bool $info_has_valid_data
  *
  */
 
@@ -156,7 +157,7 @@ $chart2__color_gradient_requests = '#AEAEAE33';
             </span>
 		<?php endif; ?>
     </div>
-    	<?php if ( ( isset( $is_tab_dashboard ) && $is_tab_dashboard ) && $is_active_app_custom && ! $is_agency ) : ?>
+    	<?php if ( ( isset( $is_tab_dashboard ) && $is_tab_dashboard ) && $is_active_app_custom && ! $is_agency && ! empty( $info_has_valid_data ) ) : ?>
     	 <span class="llar-label request <?php echo  $is_exhausted  ? 'exhausted' : '' ?>">
 	     <?php
 	     $requests_quota = isset( $requests['quota'] ) ? $requests['quota'] : '';

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -27,23 +27,27 @@ if ( $is_active_app_custom ) {
 	$block_sub_group = $this->info_sub_group();
 	$upgrade_premium_url = $this->info_upgrade_url();
 	$is_agency = $block_sub_group === 'Agency';
-	$requests = ! $is_agency ? $this->info_requests() : false;
+	$info_has_valid_data = $this->info_has_valid_data();
+	$info_is_cloud_unavailable = $this->info_is_cloud_unavailable();
+	$requests = ! $is_agency && $info_has_valid_data ? $this->info_requests() : false;
 	$is_exhausted = ! $is_agency && $this->info_is_exhausted();
 } else {
 
 	$is_exhausted = false;
+	$info_has_valid_data = false;
+	$info_is_cloud_unavailable = false;
 	$block_sub_group = '';
 	$upgrade_premium_url = '';
 }?>
 
 <div class="header_massage">
     <?php
-    if ( $is_active_app_custom && $block_sub_group === 'Micro Cloud' ) :
+    if ( $is_active_app_custom && ( $is_exhausted || $info_is_cloud_unavailable ) ) :
 
 	$notifications_message_shown = (int) Config::get( 'notifications_message_shown' );
-	$upgrade_premium_url = $this->info_upgrade_url();
-
-    if ( $is_exhausted ) :
+	if ( empty( $upgrade_premium_url ) ) {
+		$upgrade_premium_url = 'https://www.limitloginattempts.com/info.php?id=0';
+	}
 
         if ( time() > $notifications_message_shown ) : ?>
             <div id="llar-header-upgrade-premium-message" class="exhausted">
@@ -61,7 +65,7 @@ if ( $is_active_app_custom ) {
             </div>
         <?php endif; ?>
 
-    <?php else : ?>
+    <?php elseif ( $is_active_app_custom && $block_sub_group === 'Micro Cloud' && $info_has_valid_data ) : ?>
         <div id="llar-header-upgrade-mc-message">
             <p>
                 <span class="dashicons dashicons-superhero"></span>
@@ -72,8 +76,6 @@ if ( $is_active_app_custom ) {
 				?>
             </p>
         </div>
-
-        <?php endif; ?>
 
     <?php endif; ?>
 </div>

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Options page
+ *
+ * @var bool $info_has_valid_data
+ * @var bool $info_is_cloud_unavailable
+ *
+ */
 
 use LLAR\Core\Config;
 use LLAR\Core\Helpers;
@@ -46,7 +53,7 @@ if ( $is_active_app_custom ) {
 
 	$notifications_message_shown = (int) Config::get( 'notifications_message_shown' );
 	if ( empty( $upgrade_premium_url ) ) {
-		$upgrade_premium_url = 'https://www.limitloginattempts.com/info.php?id=0';
+		$upgrade_premium_url = LLA_INFO_UPGRADE_FALLBACK_URL;
 	}
 
         if ( time() > $notifications_message_shown ) : ?>


### PR DESCRIPTION
## Summary

- Show the admin network alert for `/info` only when the request fails before reaching the Cloud API (transport, DNS, timeout), not on HTTP error responses such as 403.
- When the Cloud API responds but `/info` data is unusable, show the cloud unavailable header (same pattern as exhausted quota) instead of misleading “cloud protection enabled” and monthly usage widgets.
- Add `info_has_valid_data()` and `info_is_cloud_unavailable()` helpers and gate dashboard views on valid quota/plan data.