### PR TITLE
fix: add line-height: 1 for .dashicons inside .limit-login-app-dashboard

### DIFF
--- a/assets/css/limit-login-attempts.css
+++ b/assets/css/limit-login-attempts.css
@@ -1317,6 +1317,9 @@ button.llar_button:focus, #llar-setting-page button.button:focus, .llar_button:f
 #llar-setting-page-logs__active .llar-table-scroll-wrap .llar-form-table .table-inline-preloader.loading tr td .preloader-row {
   display: inline-flex;
 }
+#llar-setting-page-logs__active.limit-login-app-dashboard .dashicons {
+  line-height: 1;
+}
 #llar-setting-page-logs__active.limit-login-app-dashboard .llar-preloader-wrap {
   position: relative;
 }
@@ -4754,3 +4757,5 @@ button.llar_button:focus, #llar-setting-page button.button:focus, .llar_button:f
 .llar-mfa-action-alert .jconfirm-content-pane, .jconfirm-type-red .jconfirm-content-pane {
   padding: 15px !important;
 }
+
+/*# sourceMappingURL=limit-login-attempts.css.map */

--- a/assets/sass/limit-login-attempts.scss
+++ b/assets/sass/limit-login-attempts.scss
@@ -1156,6 +1156,10 @@
 
   &.limit-login-app-dashboard {
 
+    .dashicons {
+      line-height: 1;
+    }
+
     .llar-preloader-wrap {
       position: relative;
 


### PR DESCRIPTION
WP 7.0 admin reskin changed the inherited `line-height` for dashicons, causing vertical misalignment of icons (help, arrows, crosses, etc.) across Dashboard, Settings, Logs, Debug, and other pages.

The fix is scoped: `line-height: 1` only for `.limit-login-app-dashboard .dashicons`. WordPress core dashicons are unaffected.

- SCSS: new block `.dashicons { line-height: 1; }` inside `&.limit-login-app-dashboard`
- CSS: recompiled