### PR TITLE
fix: show error when setup code local save fails

### DIFF
--- a/core/Ajax.php
+++ b/core/Ajax.php
@@ -143,6 +143,14 @@ class Ajax
 		wp_send_json_success( array() );
 	}
 
+	/**
+	 * @return string
+	 */
+	private function get_save_error_message() {
+
+		return __( 'The settings could not be saved due to an error on this site. Possible causes include a corrupted database or a PHP error. Please check the error logs, verify the database integrity, fix any issues found, and then try again.', 'limit-login-attempts-reloaded' );
+	}
+
 	public function app_setup_callback() {
 
 		$this->check_user_capabilities();
@@ -162,15 +170,19 @@ class Ajax
 				    ) );
                 } else {
 
+				    $error_msg = ! empty( $key_result['error'] )
+					    ? $key_result['error']
+					    : $this->get_save_error_message();
+
 				    wp_send_json_error( array(
-					    'msg' => ( $key_result['error'] )
+					    'msg' => $error_msg
 				    ) );
                 }
             } else {
 
-                wp_send_json_error( array(
-                    'msg' => $key_result['error']
-                ) );
+	            wp_send_json_error( array(
+		            'msg' => $this->get_save_error_message()
+	            ) );
             }
 		}
 

--- a/core/Ajax.php
+++ b/core/Ajax.php
@@ -143,14 +143,6 @@ class Ajax
 		wp_send_json_success( array() );
 	}
 
-	/**
-	 * @return string
-	 */
-	private function get_save_error_message() {
-
-		return __( 'The settings could not be saved due to an error on this site. Possible causes include a corrupted database or a PHP error. Please check the error logs, verify the database integrity, fix any issues found, and then try again.', 'limit-login-attempts-reloaded' );
-	}
-
 	public function app_setup_callback() {
 
 		$this->check_user_capabilities();
@@ -161,29 +153,19 @@ class Ajax
 
 			$setup_code = sanitize_text_field( $_POST['code'] );
 
-			if ( $key_result = CloudApp::activate_license_key( $setup_code ) ) {
+			$key_result = CloudApp::activate_license_key( $setup_code );
 
-			    if ( $key_result['success'] ) {
+			if ( $key_result['success'] ) {
 
-				    wp_send_json_success( array(
-					    'msg' => ( $key_result['app_config']['messages']['setup_success'] )
-				    ) );
-                } else {
+				wp_send_json_success( array(
+					'msg' => ( $key_result['app_config']['messages']['setup_success'] )
+				) );
+			} else {
 
-				    $error_msg = ! empty( $key_result['error'] )
-					    ? $key_result['error']
-					    : $this->get_save_error_message();
-
-				    wp_send_json_error( array(
-					    'msg' => $error_msg
-				    ) );
-                }
-            } else {
-
-	            wp_send_json_error( array(
-		            'msg' => $this->get_save_error_message()
-	            ) );
-            }
+				wp_send_json_error( array(
+					'msg' => ( $key_result['error'] )
+				) );
+			}
 		}
 
 		wp_send_json_error( array(

--- a/core/CloudApp.php
+++ b/core/CloudApp.php
@@ -154,8 +154,19 @@ class CloudApp
 
 	public static function activate_license_key( $setup_code )
 	{
-		$link = strrev( $setup_code );
+		$link         = strrev( $setup_code );
 		$setup_result = self::setup( $link );
+
+		/**
+		 * Filters the result of the remote setup() call.
+		 *
+		 * Intended for integration tests to stub the remote response without
+		 * performing a real HTTP request.
+		 *
+		 * @param array  $setup_result Result from setup().
+		 * @param string $setup_code   Original setup code.
+		 */
+		$setup_result = apply_filters( 'llar_app_setup_result', $setup_result, $setup_code );
 
 		if ( $setup_result['success'] ) {
 
@@ -167,10 +178,23 @@ class CloudApp
 
 				// Verify the setup code persisted before switching the active app, to avoid
 				// an inconsistent state (active app set to "custom" without a setup code).
-				if ( Config::get( 'app_setup_code' ) !== $setup_code ) {
+				$persisted_code = Config::get( 'app_setup_code' );
+
+				/**
+				 * Filters the read-back value of the persisted setup code.
+				 *
+				 * Intended for integration tests to simulate a storage failure: returning
+				 * a value that differs from $setup_code forces the save-error branch.
+				 *
+				 * @param string $persisted_code Value read back from storage.
+				 * @param string $setup_code     The code that was just saved.
+				 */
+				$persisted_code = apply_filters( 'llar_app_setup_code_readback', $persisted_code, $setup_code );
+
+				if ( $persisted_code !== $setup_code ) {
 
 					$setup_result['success'] = false;
-					$setup_result['error']   = __( 'The settings could not be saved due to an error on this site. Please check the error logs and try again.', 'limit-login-attempts-reloaded' );
+					$setup_result['error']   = __( 'The settings could not be saved due to an error on this site. Possible causes include a corrupted database or a PHP error. Please check the error logs, verify the database integrity, fix any issues found, and then try again.', 'limit-login-attempts-reloaded' );
 
 					return $setup_result;
 				}

--- a/core/CloudApp.php
+++ b/core/CloudApp.php
@@ -125,7 +125,9 @@ class CloudApp
 
 		if ( ! empty( $setup_response['error'] ) ) {
 
-			$return['error'] = $setup_response['error'];
+			$return['error'] = ! empty( $setup_response['status'] )
+				? $setup_response['error']
+				: __( 'The endpoint is not responding. Please contact your app provider to settle that.', 'limit-login-attempts-reloaded' );
 
 		} elseif( $setup_response['status'] === 200 ) {
 
@@ -157,6 +159,13 @@ class CloudApp
 
 				Config::update( Config::OPTION_ACTIVE_APP, 'custom' );
 				Config::update( 'app_setup_code', $setup_code );
+
+				// Verify persistence by reading values back
+				if ( Config::get( Config::OPTION_ACTIVE_APP ) !== 'custom'
+				     || Config::get( 'app_setup_code' ) !== $setup_code ) {
+
+					return false;
+				}
 
 				$setup_result['app_config']['messages']['setup_success'] =
 					! empty( $setup_result['app_config']['messages']['setup_success'] )

--- a/core/CloudApp.php
+++ b/core/CloudApp.php
@@ -125,9 +125,15 @@ class CloudApp
 
 		if ( ! empty( $setup_response['error'] ) ) {
 
-			$return['error'] = ! empty( $setup_response['status'] )
-				? $setup_response['error']
-				: __( 'The endpoint is not responding. Please contact your app provider to settle that.', 'limit-login-attempts-reloaded' );
+			if ( ! empty( $setup_response['status'] ) ) {
+				// HTTP-level error with a response - the message is user-facing.
+				$return['error'] = $setup_response['error'];
+			} else {
+				// Transport-level failure (DNS, timeout, etc.) - keep the raw error for diagnostics.
+				error_log( 'Limit Login Attempts Reloaded: app setup request transport error - ' . $setup_response['error'] );
+
+				$return['error'] = __( 'The endpoint is not responding. Please contact your app provider to settle that.', 'limit-login-attempts-reloaded' );
+			}
 
 		} elseif( $setup_response['status'] === 200 ) {
 
@@ -157,15 +163,19 @@ class CloudApp
 
 				Helpers::cloud_app_update_config( $setup_result['app_config'], true );
 
-				Config::update( Config::OPTION_ACTIVE_APP, 'custom' );
 				Config::update( 'app_setup_code', $setup_code );
 
-				// Verify persistence by reading values back
-				if ( Config::get( Config::OPTION_ACTIVE_APP ) !== 'custom'
-				     || Config::get( 'app_setup_code' ) !== $setup_code ) {
+				// Verify the setup code persisted before switching the active app, to avoid
+				// an inconsistent state (active app set to "custom" without a setup code).
+				if ( Config::get( 'app_setup_code' ) !== $setup_code ) {
 
-					return false;
+					$setup_result['success'] = false;
+					$setup_result['error']   = __( 'The settings could not be saved due to an error on this site. Please check the error logs and try again.', 'limit-login-attempts-reloaded' );
+
+					return $setup_result;
 				}
+
+				Config::update( Config::OPTION_ACTIVE_APP, 'custom' );
 
 				$setup_result['app_config']['messages']['setup_success'] =
 					! empty( $setup_result['app_config']['messages']['setup_success'] )


### PR DESCRIPTION
- Verify persistence after `Config::update()` via read-back (`Config::get()`), not return value
- `update_option()` returns `false` both on "value unchanged" and on real DB error — read-back disambiguates
- Show descriptive error message when save truly fails